### PR TITLE
COR-FIX unsuccessful product sync attemps in not normal sync

### DIFF
--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -232,6 +232,15 @@ class Data extends Main
     }
 
     /**
+     * @param $itemData
+     * @return array
+     */
+    public function getMinimalProductRequestData($itemData) {
+        $magentoProductId = $itemData->getData('entity_id');
+        return ['external_id' => $magentoProductId];
+    }
+
+    /**
      * Fetch yotpo data from yotpo_product_sync
      * @param array<int, int> $productsId
      * @param array<int|string, int|string> $parentIds

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -771,23 +771,23 @@ class Processor extends Main
     }
 
     /**
-     * Get the productIds od the products that are not synced
+     * Get the productIds of the items in the cart that are not synced
      *
      * @param array <mixed> $productIds
-     * @param array $visibleItems
+     * @param array $visibleItemsInCart
      * @param string $storeId
      * @return mixed
      */
-    public function getUnSyncedProductIds($productIds, $visibleItems, $storeId)
+    public function getUnSyncedProductIds($cartItemIdsToYotpo, $visibleItemsInCart, $storeId)
     {
-        $itemsMap = [];
-        foreach ($visibleItems as $visibleItem) {
+        $visibleItemIdToProductMap = [];
+        foreach ($visibleItemsInCart as $visibleItem) {
             $product = $visibleItem->getProduct();
             if (!$product) {
                 continue;
             }
-            $itemsMap[$product->getId()] = $product;
+            $visibleItemIdToProductMap[$product->getId()] = $product;
         }
-        return $this->syncDataMain->getProductIds($productIds, $storeId, $itemsMap);
+        return $this->syncDataMain->getMissingItemIdsInProductsSyncTable($cartItemIdsToYotpo, $storeId, $visibleItemIdToProductMap);
     }
 }

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -350,7 +350,6 @@ class Processor extends Main
                 if (count($returnResponse['four_not_four_data'])) {
                     foreach ($returnResponse['four_not_four_data'] as $retryId) {
                         if ($this->isImmediateRetry($response, $this->entity, $visibleVariants.$retryId, $storeId)) {
-                            $this->setImmediateRetryAlreadyDone($this->entity, $visibleVariants.$retryId, $storeId);
                             $this->retryItems[$storeId][$retryId] = $retryId;
                         }
                     }

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -13,6 +13,7 @@ use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Framework\Stdlib\DateTime\DateTime;
 use Yotpo\Core\Model\Sync\Category\Processor\ProcessByProduct as CategorySyncProcessor;
 use Magento\Quote\Model\Quote;
+use Yotpo\Core\Model\Sync\Data\Main as SyncDataMain;
 use Yotpo\Core\Model\Sync\Catalog\Processor\Main;
 use Yotpo\Core\Api\ProductSyncRepositoryInterface;
 
@@ -25,6 +26,11 @@ class Processor extends Main
      * @var CatalogData
      */
     protected $catalogData;
+
+    /**
+     * @var SyncDataMain
+     */
+    protected $syncDataMain;
 
     /**
      * @var DateTime
@@ -69,6 +75,7 @@ class Processor extends Main
      * @param YotpoResource $yotpoResource ,
      * @param CategorySyncProcessor $categorySyncProcessor
      * @param ProductSyncRepositoryInterface $productSyncRepositoryInterface
+     * @param SyncDataMain $syncDataMain
      */
     public function __construct(
         AppEmulation $appEmulation,
@@ -81,7 +88,8 @@ class Processor extends Main
         DateTime $dateTime,
         YotpoResource $yotpoResource,
         CategorySyncProcessor $categorySyncProcessor,
-        ProductSyncRepositoryInterface $productSyncRepositoryInterface
+        ProductSyncRepositoryInterface $productSyncRepositoryInterface,
+        SyncDataMain $syncDataMain
     ) {
         parent::__construct(
             $appEmulation,
@@ -96,41 +104,19 @@ class Processor extends Main
         $this->dateTime = $dateTime;
         $this->categorySyncProcessor = $categorySyncProcessor;
         $this->productSyncRepositoryInterface = $productSyncRepositoryInterface;
-    }
-
-    /**
-     * Sync products during checkout
-     * @param null|array <mixed> $unSyncedProductIds
-     * @return bool
-     */
-    public function processCheckoutProducts($unSyncedProductIds)
-    {
-        $this->normalSync = false;
-        try {
-            $storeId = $this->coreConfig->getStoreId();
-            $collection = $this->getCollectionForSync($unSyncedProductIds);
-            $this->syncItems($collection->getItems(), $storeId);
-            return true;
-        } catch (NoSuchEntityException $e) {
-            return false;
-        }
+        $this->syncDataMain = $syncDataMain;
     }
 
     /**
      * Process the Catalog Api
      * @param array <mixed> $forceSyncProducts
-     * @param Order|Quote $order
-     * @param array <mixed> $storeIds
+     * @param array $storeIds
      * @return bool
      */
-    public function process($forceSyncProducts = [], $order = null, $storeIds = [])
+    public function process($forceSyncProducts = [], $storeIds = [])
     {
         try {
-            if ($order) {
-                $allStores = [$order->getStoreId()];
-            } else {
-                $allStores = array_unique($storeIds) ?: (array)$this->coreConfig->getAllStoreIds(false);
-            }
+            $allStores = array_unique($storeIds) ?: (array)$this->coreConfig->getAllStoreIds(false);
             $unSyncedStoreIds = [];
             foreach ($allStores as $storeId) {
                 if ($this->isCommandLineSync) {
@@ -156,7 +142,7 @@ class Processor extends Main
                                 $this->coreConfig->getStoreName($storeId) . PHP_EOL;
                         }
                     }
-                    if (!$order && !$this->coreConfig->isCatalogSyncActive()) {
+                    if ($this->normalSync && !$this->coreConfig->isCatalogSyncActive()) {
                         $disabled = true;
                         $this->yotpoCatalogLogger->info(
                             __(
@@ -212,7 +198,7 @@ class Processor extends Main
                 $this->stopEnvironmentEmulation();
             }
             $this->stopEnvironmentEmulation();
-            if ($order && in_array($order->getStoreId(), $unSyncedStoreIds)) {
+            if (!$this->normalSync && count($unSyncedStoreIds) > 0) {
                 return false;
             } else {
                 return true;
@@ -306,7 +292,7 @@ class Processor extends Main
                     'sync_status' => 1
                 ];
                 if (!$visibleVariants) {
-                    $tempSqlArray['yotpo_id_parent']  = $apiParam['yotpo_id_parent'] ?: 0;
+                    $tempSqlArray['yotpo_id_parent'] = $apiParam['yotpo_id_parent'] ?: 0;
                 }
                 if ($this->coreConfig->canUpdateCustomAttributeForProducts($tempSqlArray['response_code'])) {
                     $tempSqlDataIntTable = [
@@ -718,10 +704,52 @@ class Processor extends Main
             $productByStore[$item['store_id']][] = $item['product_id'];
         }
         if ($productIds) {
-            $this->process($productByStore, null, array_unique($storeIds));
+            $this->process($productByStore, array_unique($storeIds));
         } else {
             // phpcs:ignore
             echo 'No catalog data to process.' . PHP_EOL;
         }
+    }
+
+    /**
+     * Check and sync the products if not already synced
+     *
+     * @param array <mixed> $productIds
+     * @param array $visibleItems
+     * @param string $storeId
+     * @return bool
+     */
+    public function syncProducts($productIds, $visibleItems, $storeId)
+    {
+        $unSyncedProductIds = $this->getUnSyncedProductIds($productIds, $visibleItems, $storeId);
+        if ($unSyncedProductIds) {
+            $this->setNormalSyncFlag(false);
+            $sync = $this->process($unSyncedProductIds, [$storeId]);
+            $coreConfigStoreId = $this->coreConfig->getStoreId();
+            $this->emulateFrontendArea($coreConfigStoreId);
+            return $sync;
+        }
+        return true;
+    }
+
+    /**
+     * Get the productIds od the products that are not synced
+     *
+     * @param array <mixed> $productIds
+     * @param array $visibleItems
+     * @param string $storeId
+     * @return mixed
+     */
+    public function getUnSyncedProductIds($productIds, $visibleItems, $storeId)
+    {
+        $itemsMap = [];
+        foreach ($visibleItems as $visibleItem) {
+            $product = $visibleItem->getProduct();
+            if (!$product) {
+                continue;
+            }
+            $itemsMap[$product->getId()] = $product;
+        }
+        return $this->syncDataMain->getProductIds($productIds, $storeId, $itemsMap);
     }
 }

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -698,21 +698,31 @@ class Processor extends Main
 
     /**
      * Prepare products to sync their category data
-     * @param array<mixed> $data
-     * @param array<mixed> $collectionItems
+     * @param array<mixed> $productsSyncAttempt
+     * @param array<mixed> $collectionItemsToSync
      * @param array<mixed> $dataForCategorySync
      * @return array<mixed>
      */
-    protected function getProductsForCategorySync($data, $collectionItems, array $dataForCategorySync): array
+    protected function getProductsForCategorySync($productsSyncAttempt, $collectionItemsToSync, array $dataForCategorySync): array
     {
-        foreach ($data as $dataItem) {
-            foreach ($collectionItems as $item) {
-                if ($item->getId() == $dataItem['product_id']) {
-                    $dataForCategorySync[$dataItem['yotpo_id']] = $item;
-                    break;
-                }
+        $storeId = $this->coreConfig->getStoreId();
+        $retryItems = [];
+        if ($this->retryItems && isset($this->retryItems[$storeId])) {
+            $retryItems = $this->retryItems[$storeId];
+        }
+
+        $collectionItemIdToCollectionItemMap = [];
+        foreach ($collectionItemsToSync as $itemToSync) {
+            $collectionItemIdToCollectionItemMap[$itemToSync->getId()] = $itemToSync;
+        }
+
+        foreach ($productsSyncAttempt as $productSyncAttempt) {
+            $magentoProductId = $productSyncAttempt['product_id'];
+            if (!isset($retryItems[$magentoProductId])) {
+                $dataForCategorySync[$magentoProductId] = $collectionItemIdToCollectionItemMap[$magentoProductId];
             }
         }
+
         return $dataForCategorySync;
     }
 

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -404,7 +404,7 @@ class Main extends AbstractJobs
 
                 if (!$this->getImmediateRetryAlreadyDone(
                     $this->entity,
-                    (int)$productId,
+                    $visibleVariants.(int)$productId,
                     $this->coreConfig->getStoreId()
                 )) {
                     $existingProduct = $this->getExistingProductsFromAPI($url, $productId, 'products');
@@ -417,6 +417,11 @@ class Main extends AbstractJobs
                         );
                         $method = $this->coreConfig->getProductSyncMethod('updateProduct');
                     }
+                    $this->setImmediateRetryAlreadyDone(
+                        $this->entity,
+                        $visibleVariants.(int)$productId,
+                        $this->coreConfig->getStoreId()
+                    );
                 }
             }
 
@@ -429,7 +434,7 @@ class Main extends AbstractJobs
 
                 if (!$this->getImmediateRetryAlreadyDone(
                     $this->entity,
-                    (int)$productId,
+                    $visibleVariants.(int)$productId,
                     $this->coreConfig->getStoreId()
                 )) {
                     $existingVariant = $this->getExistingProductsFromAPI($url, $productId, 'variants');
@@ -442,6 +447,11 @@ class Main extends AbstractJobs
                         );
                         $method = $this->coreConfig->getProductSyncMethod('updateProductVariant');
                     }
+                    $this->setImmediateRetryAlreadyDone(
+                        $this->entity,
+                        $visibleVariants.(int)$productId,
+                        $this->coreConfig->getStoreId()
+                    );
                 }
             }
         }

--- a/Model/Sync/Data/Main.php
+++ b/Model/Sync/Data/Main.php
@@ -64,26 +64,6 @@ class Main
     }
 
     /**
-     * Get the productIds od the products that are not synced
-     *
-     * @param array <mixed> $productIds
-     * @param Order $order
-     * @return mixed
-     */
-    public function getUnSyncedProductIds($productIds, $order)
-    {
-        $orderItems = [];
-        foreach ($order->getAllVisibleItems() as $orderItem) {
-            $product = $orderItem->getProduct();
-            if (!$product) {
-                continue;
-            }
-            $orderItems[$product->getId()] = $product;
-        }
-        return $this->getProductIds($productIds, $order->getStoreId(), $orderItems);
-    }
-
-    /**
      * Get product ids
      *
      * @param array <mixed> $productIds

--- a/Model/Sync/Orders/Processor.php
+++ b/Model/Sync/Orders/Processor.php
@@ -438,7 +438,9 @@ class Processor extends Main
         $this->yotpoOrdersLogger->info('Orders sync - data prepared - Order ID - ' . $orderId, []);
         $productIds = $this->data->getLineItemsIds();
         if ($productIds) {
-            $isProductSyncSuccess = $this->checkAndSyncProducts($productIds, $order);
+            $visibleItems = $order->getAllVisibleItems();
+            $storeId = $order->getStoreId();
+            $isProductSyncSuccess = $this->catalogProcessor->syncProducts($productIds, $visibleItems, $storeId);
             if (!$isProductSyncSuccess) {
                 $this->yotpoOrdersLogger->info('Products sync failed - Order ID - ' . $order->getId(), []);
                 return [];
@@ -492,25 +494,6 @@ class Processor extends Main
             echo 'Order process completed for orderId - ' . $orderId . PHP_EOL;
         }
         return $response;
-    }
-
-    /**
-     * Check and sync the products if not already synced
-     *
-     * @param array <mixed> $productIds
-     * @param Order $order
-     * @return bool
-     */
-    public function checkAndSyncProducts($productIds, $order)
-    {
-        $unSyncedProductIds = $this->data->getUnSyncedProductIds($productIds, $order);
-        if ($unSyncedProductIds) {
-            $this->catalogProcessor->setNormalSyncFlag(false);
-            $sync = $this->catalogProcessor->process($unSyncedProductIds, $order);
-            $this->emulateFrontendArea($this->currentStoreId);
-            return $sync;
-        }
-        return true;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-core",
     "description": "Yotpo Reviews core extension for Magento2",
-    "version": "4.0.18",
+    "version": "4.1.0",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_Core" setup_version="4.0.18" />
+    <module name="Yotpo_Core" setup_version="4.1.0" />
 </config>


### PR DESCRIPTION
**Issue 1**
Products sync that was triggered from orders or checkouts sync, never returns an indication that products failed the sync process if an exception was not raised.
This causes us to get 404 responses in the order/checkout creation/update.

**Issue 2**
`getProductsForCategorySync` returns products that failed the sync process.
This leads to syncing categories for products that failed the sync process.

**Issue 3**
`getUnSyncedProductIds` returned value does not contain all the unsynced products, when one of the product (or more) does not exist in the Yotpo sync table (`yotpo_products_sync`).
It caused products to not be synced prior to orders/checkouts sync process, which would lead to a 404 exception.

**Issue 4**
`setImmediateRetryAlreadyDone` was placed before immediateRetry was actually done.