### PR TITLE
Cor fix products sync process in non normal sync

### DIFF
--- a/Model/Api/ErrorHandler.php
+++ b/Model/Api/ErrorHandler.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Yotpo\Core\Model\Api;
+
+use Yotpo\Core\Model\Config;
+
+class ErrorHandler
+{
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    /**
+     * @var CoreSync
+     */
+    protected $coreSync;
+
+    /**
+     * Request constructor.
+     * @param Config $config
+     * @param Sync $coreSync
+     */
+    public function __construct(
+        Config $config,
+        Sync $coreSync
+    ) {
+        $this->config = $config;
+        $this->coreSync = $coreSync;
+    }
+
+    public function handleConflictResponse($entityId, $entityTypeInYotpoApi, $entityDataToSync, $parentTypeInYotpoApi = null, $parentYotpoId = null)
+    {
+        $getEndpointUrl = $this->config->buildYotpoEntityRequestUrl($entityTypeInYotpoApi, $this->config::METHOD_GET, null, $parentTypeInYotpoApi, $parentYotpoId);
+        $entityYotpoId = $this->getYotpoIdFromMagentoEntityId($entityId, $getEndpointUrl, $entityTypeInYotpoApi);
+        if (!$entityYotpoId) {
+            return false;
+        }
+
+        $patchEndpointUrl = $this->config->buildYotpoEntityRequestUrl($entityTypeInYotpoApi, $this->config::METHOD_PATCH, $entityYotpoId, $parentTypeInYotpoApi, $parentYotpoId);
+        return $this->updateExistingEntityInYotpo($entityYotpoId, $patchEndpointUrl, $entityDataToSync);
+    }
+
+    public function handleNotFoundResponse($entityId, $entityTypeInYotpoApi, $entityDataToSync, $parentTypeInYotpoApi = null, $parentYotpoId = null)
+    {
+        $getEndpointUrl = $this->config->buildYotpoEntityRequestUrl($entityTypeInYotpoApi, $this->config::METHOD_GET, null, $parentTypeInYotpoApi, $parentYotpoId);
+        $entityYotpoId = $this->getYotpoIdFromMagentoEntityId($entityId, $getEndpointUrl, $entityTypeInYotpoApi);
+        if ($entityYotpoId === false) {
+            return false;
+        }
+
+        if ($entityYotpoId == 0) {
+            $postEndpointUrl = $this->config->buildYotpoEntityRequestUrl($entityTypeInYotpoApi, $this->config::METHOD_POST, $entityYotpoId, $parentTypeInYotpoApi, $parentYotpoId);
+            return $this->createEntityInYotpo($entityYotpoId, $postEndpointUrl, $entityDataToSync);
+        }
+
+        $patchEndpointUrl = $this->config->buildYotpoEntityRequestUrl($entityTypeInYotpoApi, $this->config::METHOD_PATCH, $entityYotpoId, $parentTypeInYotpoApi, $parentYotpoId);
+        return $this->updateExistingEntityInYotpo($entityYotpoId, $patchEndpointUrl, $entityDataToSync);
+    }
+
+    private function getYotpoIdFromMagentoEntityId($entityId, $getEndpointUrl, $entityTypeKeyInYotpoApi) {
+        $getRequestPayload = ['external_ids' => $entityId, 'entityLog' => $entityTypeKeyInYotpoApi];
+        $getResponseData = $this->coreSync->sync($this->config::METHOD_GET, $getEndpointUrl, $getRequestPayload);
+        if (!$getResponseData->getData('is_success')) {
+            return false;
+        }
+
+        $responseData = $getResponseData->getResponse();
+        if (!$responseData || !is_array($responseData)) {
+            if (!array_key_exists($entityTypeKeyInYotpoApi, $responseData) || count($responseData[$entityTypeKeyInYotpoApi]) == 0) {
+                return 0;
+            }
+        }
+
+        $existingEntitiesInYotpo = $responseData[$entityTypeKeyInYotpoApi];
+        $existingEntityInYotpo = $existingEntitiesInYotpo[0];
+        return $existingEntityInYotpo['yotpo_id'];
+    }
+
+    private function createEntityInYotpo($entityYotpoId, $postEndpointUrl, $entityDataToSync) {
+        $postResponseData = $this->coreSync->sync($this->config::METHOD_POST, $postEndpointUrl, $entityDataToSync);
+        if (!$postResponseData->getData('is_success')) {
+            return false;
+        }
+
+        return $entityYotpoId;
+    }
+
+    private function updateExistingEntityInYotpo($entityYotpoId, $patchEndpointUrl, $entityDataToSync) {
+        $patchResponseData = $this->coreSync->sync($this->config::METHOD_PATCH, $patchEndpointUrl, $entityDataToSync);
+        if (!$patchResponseData->getData('is_success')) {
+            return false;
+        }
+
+        return $entityYotpoId;
+    }
+}

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -1,6 +1,7 @@
 <?php
 namespace Yotpo\Core\Model;
 
+use http\Exception\InvalidArgumentException;
 use Magento\Eav\Model\Entity;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Exception\LocalizedException;
@@ -29,6 +30,9 @@ class Config
     const YOTPO_RETRY_ATTEMPTS_AMOUNT = 3;
 
     const MODULE_NAME = 'Yotpo_Core';
+
+    const BOTH_PARENT_ENTITY_TYPE_AND_PARENT_ENTITY_ID_REQUIRED_EXCEPTION_MESSAGE = "Both parent type and parent ID are required";
+    const ENTITY_ID_REQUIRED_FOR_PATCH_EXCEPTION_MESSAGE = "Yotpo entity ID is required for PATCH requests";
 
     /**
      * API method types
@@ -673,5 +677,23 @@ class Config
     public function getYotpoRetryAttemptsAmount(): int
     {
         return self::YOTPO_RETRY_ATTEMPTS_AMOUNT;
+    }
+
+    public function buildYotpoEntityRequestUrl($yotpoEntityType, $requestMethod, $yotpoEntityId = null, $yotpoParentEntityType = null, $yotpoParentId = null) {
+        if (!($yotpoParentEntityType && $yotpoParentId)) {
+            throw new InvalidArgumentException(self::BOTH_PARENT_ENTITY_TYPE_AND_PARENT_ENTITY_ID_REQUIRED_EXCEPTION_MESSAGE);
+        }
+
+        $urlComponents = [$yotpoParentEntityType, $yotpoParentId, $yotpoEntityType];
+
+        if ($requestMethod == self::METHOD_PATCH) {
+            if (!$yotpoEntityId) {
+                throw new InvalidArgumentException(self::ENTITY_ID_REQUIRED_FOR_PATCH_EXCEPTION_MESSAGE);
+            }
+
+            $urlComponents[] = $yotpoEntityId;
+        }
+
+        return join('/', array_filter($urlComponents));
     }
 }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -43,6 +43,8 @@ class Config
     const CUSTOM_RESPONSE_DATA = '000';
     const SUCCESS_RESPONSE_CODE = '200';
     const BAD_REQUEST_RESPONSE_CODE = 400;
+    const NOT_FOUND_RESPONSE_CODE = 404;
+    const CONFLICT_RESPONSE_CODE = 409;
 
     /**
      * @var mixed[]

--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -232,6 +232,15 @@ class Data extends Main
     }
 
     /**
+     * @param $itemData
+     * @return array
+     */
+    public function getMinimalProductRequestData($itemData) {
+        $magentoProductId = $itemData['external_id'];
+        return ['external_id' => $magentoProductId];
+    }
+
+    /**
      * Fetch yotpo data from yotpo_product_sync
      * @param array<int, int> $productsId
      * @param array<int|string, int|string> $parentIds

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -227,8 +227,8 @@ class Processor extends Main
         $syncedToYotpoProductAttributeId = $this->catalogData->getAttributeId(CoreConfig::CATALOG_SYNC_ATTR_CODE);
         $items = $this->manageSyncItems($collectionItems, $visibleVariants);
         $parentIds = $items['parent_ids'];
-        $yotpoData = $items['yotpo_data'];
         $parentData = $items['parent_data'];
+        $yotpoSyncTableItemsData = $items['yotpo_data'];
 
         $lastSyncTime = '';
         $sqlData = $sqlDataIntTable = [];
@@ -240,9 +240,9 @@ class Processor extends Main
             $rowId = $itemData['row_id'];
             unset($itemData['row_id']);
 
-            if ($this->isSyncingAsMainEntity() && $yotpoData && array_key_exists($itemId, $yotpoData)) {
-                if (!$this->coreConfig->canResync($yotpoData[$itemId]['response_code'],
-                    $yotpoData[$itemId],
+            if ($this->isSyncingAsMainEntity() && $yotpoSyncTableItemsData && array_key_exists($itemId, $yotpoSyncTableItemsData)) {
+                if (!$this->coreConfig->canResync($yotpoSyncTableItemsData[$itemId]['response_code'],
+                    $yotpoSyncTableItemsData[$itemId],
                     $this->isCommandLineSync)) {
                     $tempSqlDataIntTable = [
                         'attribute_id' => $syncedToYotpoProductAttributeId,
@@ -260,8 +260,8 @@ class Processor extends Main
                 }
             }
 
-            $yotpoData[$itemId]['yotpo_id'];
-            $apiParam = $this->getApiParams($itemId, $yotpoData, $parentIds, $parentData, $visibleVariants);
+            $yotpoSyncTableItemsData[$itemId]['yotpo_id'];
+            $apiParam = $this->getApiParams($itemId, $yotpoSyncTableItemsData, $parentIds, $parentData, $visibleVariants);
 
             if (!$apiParam) {
                 $parentProductId = $parentIds[$itemId] ?? 0;

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -269,19 +269,13 @@ class Processor extends Main
 
             $response = $this->processRequest($apiRequestParams, $magentoItemData);
 
-            $lastSyncTime = $this->getCurrentTime();
             $yotpoIdKey = $visibleVariants ? 'visible_variant_yotpo_id' : 'yotpo_id';
-            $syncDataRecordToUpdate = [
-                'product_id' => $itemEntityId,
-                $yotpoIdKey => $apiRequestParams['yotpo_id'] ?: 0,
-                'store_id' => $storeId,
-                'synced_to_yotpo' => $lastSyncTime,
-                'response_code' => $response->getData('status'),
-                'sync_status' => 1
-            ];
+            $yotpoIdValue = $apiRequestParams['yotpo_id'] ?: 0;
+            $syncDataRecordToUpdate = $this->prepareSyncTableDataToUpdate($itemEntityId, $yotpoIdKey, $yotpoIdValue, $storeId, $response->getData('status'));
             if (!$visibleVariants) {
                 $syncDataRecordToUpdate['yotpo_id_parent'] = $apiRequestParams['yotpo_id_parent'] ?: 0;
             }
+
             if ($this->coreConfig->canUpdateCustomAttributeForProducts($syncDataRecordToUpdate['response_code'])) {
                 $attributeDataToUpdate = $this->prepareAttributeDataToUpdate($storeId, $itemRowId, $syncedToYotpoProductAttributeId);
                 if ($this->isSyncingAsMainEntity()) {
@@ -753,5 +747,18 @@ class Processor extends Main
             'catalog_product_entity_int',
             [$attributeDataToUpdate]
         );
+    }
+
+    private function prepareSyncTableDataToUpdate($itemEntityId, $yotpoIdKey, $yotpoIdValue, $storeId, $responseCode, $yotpoParentId = null)
+    {
+        $lastSyncTime = $this->getCurrentTime();
+        return [
+            'product_id' => $itemEntityId,
+            $yotpoIdKey => $yotpoIdValue,
+            'yotpo_id_parent' => $yotpoParentId,
+            'store_id' => $storeId,
+            'synced_to_yotpo' => $lastSyncTime,
+            'response_code' => $responseCode
+        ];
     }
 }

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -271,7 +271,7 @@ class Processor extends Main
 
             $lastSyncTime = $this->getCurrentTime();
             $yotpoIdKey = $visibleVariants ? 'visible_variant_yotpo_id' : 'yotpo_id';
-            $tempSqlArray = [
+            $syncDataRecordToUpdate = [
                 'product_id' => $itemEntityId,
                 $yotpoIdKey => $apiRequestParams['yotpo_id'] ?: 0,
                 'store_id' => $storeId,
@@ -280,9 +280,9 @@ class Processor extends Main
                 'sync_status' => 1
             ];
             if (!$visibleVariants) {
-                $tempSqlArray['yotpo_id_parent'] = $apiRequestParams['yotpo_id_parent'] ?: 0;
+                $syncDataRecordToUpdate['yotpo_id_parent'] = $apiRequestParams['yotpo_id_parent'] ?: 0;
             }
-            if ($this->coreConfig->canUpdateCustomAttributeForProducts($tempSqlArray['response_code'])) {
+            if ($this->coreConfig->canUpdateCustomAttributeForProducts($syncDataRecordToUpdate['response_code'])) {
                 $attributeDataToUpdate = $this->prepareAttributeDataToUpdate($storeId, $itemRowId, $syncedToYotpoProductAttributeId);
                 if ($this->isSyncingAsMainEntity()) {
                     $this->updateAttributeData($attributeDataToUpdate);
@@ -292,13 +292,13 @@ class Processor extends Main
             $returnResponse = $this->processResponse(
                 $apiRequestParams,
                 $response,
-                $tempSqlArray,
+                $syncDataRecordToUpdate,
                 $magentoItemData,
                 $externalIds,
                 $visibleVariants
             );
 
-            $tempSqlArray = $returnResponse['temp_sql'];
+            $syncDataRecordToUpdate = $returnResponse['temp_sql'];
             $externalIds = $returnResponse['external_id'];
 
             if (isset($this->retryItems[$storeId][$itemEntityId])) {
@@ -317,15 +317,15 @@ class Processor extends Main
             //push to parentData array if parent product is
             // being the part of current collection
             if (!$visibleVariants) {
-                $parentItemsData = $this->pushParentData((int)$itemEntityId, $tempSqlArray, $parentItemsData, $parentItemsIds);
+                $parentItemsData = $this->pushParentData((int)$itemEntityId, $syncDataRecordToUpdate, $parentItemsData, $parentItemsIds);
             }
             $syncDataSql = [];
-            $syncDataSql[] = $tempSqlArray;
+            $syncDataSql[] = $syncDataRecordToUpdate;
             $this->insertOnDuplicate(
                 'yotpo_product_sync',
                 $syncDataSql
             );
-            $sqlData[] = $tempSqlArray;
+            $sqlData[] = $syncDataRecordToUpdate;
         }
         $dataToSent = [];
         if (count($sqlData)) {

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -292,7 +292,7 @@ class Processor extends Main
                 $visibleVariants
             );
 
-            $syncDataRecordToUpdate = $returnResponse['temp_sql'];
+            $processedSyncDataRecordToUpdate = $returnResponse['temp_sql'];
             $externalIds = $returnResponse['external_id'];
 
             if (isset($this->retryItems[$storeId][$itemEntityId])) {
@@ -311,16 +311,15 @@ class Processor extends Main
             //push to parentData array if parent product is
             // being the part of current collection
             if (!$visibleVariants) {
-                $parentItemsData = $this->pushParentData((int)$itemEntityId, $syncDataRecordToUpdate, $parentItemsData, $parentItemsIds);
+                $parentItemsData = $this->pushParentData((int)$itemEntityId, $processedSyncDataRecordToUpdate, $parentItemsData, $parentItemsIds);
             }
-            $syncDataSql = [];
-            $syncDataSql[] = $syncDataRecordToUpdate;
             $this->insertOnDuplicate(
                 'yotpo_product_sync',
-                $syncDataSql
+                [$processedSyncDataRecordToUpdate]
             );
-            $sqlData[] = $syncDataRecordToUpdate;
+            $sqlData[] = $processedSyncDataRecordToUpdate;
         }
+
         $dataToSent = [];
         if (count($sqlData)) {
             $dataToSent = array_merge($dataToSent, $this->catalogData->filterDataForCatSync($sqlData));

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -244,10 +244,7 @@ class Processor extends Main
             if ($this->isSyncingAsMainEntity() && $yotpoSyncTableItemsData && array_key_exists($itemEntityId, $yotpoSyncTableItemsData)) {
                 if (!$this->shouldItemBeResynced($yotpoSyncTableItemsData[$itemEntityId])) {
                     $attributeDataToUpdate = $this->prepareAttributeDataToUpdate($storeId, $itemRowId, $syncedToYotpoProductAttributeId);
-                    $this->insertOnDuplicate(
-                        'catalog_product_entity_int',
-                        [$attributeDataToUpdate]
-                    );
+                    $this->updateAttributeData($attributeDataToUpdate);
                     continue;
                 }
             }
@@ -290,10 +287,7 @@ class Processor extends Main
             if ($this->coreConfig->canUpdateCustomAttributeForProducts($tempSqlArray['response_code'])) {
                 $attributeDataToUpdate = $this->prepareAttributeDataToUpdate($storeId, $itemRowId, $syncedToYotpoProductAttributeId);
                 if ($this->isSyncingAsMainEntity()) {
-                    $this->insertOnDuplicate(
-                        'catalog_product_entity_int',
-                        [$attributeDataToUpdate]
-                    );
+                    $this->updateAttributeData($attributeDataToUpdate);
                 }
             }
 
@@ -754,5 +748,12 @@ class Processor extends Main
             'value' => 1,
             $this->entityIdFieldValue => $itemRowId
         ];
+    }
+
+    private function updateAttributeData($attributeDataToUpdate) {
+        $this->insertOnDuplicate(
+            'catalog_product_entity_int',
+            [$attributeDataToUpdate]
+        );
     }
 }

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -226,7 +226,7 @@ class Processor extends Main
 
         $syncedToYotpoProductAttributeId = $this->catalogData->getAttributeId(CoreConfig::CATALOG_SYNC_ATTR_CODE);
         $items = $this->manageSyncItems($collectionItems, $visibleVariants);
-        $parentIds = $items['parent_ids'];
+        $parentItemsIds = $items['parent_ids'];
         $parentData = $items['parent_data'];
         $yotpoSyncTableItemsData = $items['yotpo_data'];
 
@@ -261,10 +261,10 @@ class Processor extends Main
             }
 
             $yotpoSyncTableItemsData[$itemId]['yotpo_id'];
-            $apiParam = $this->getApiParams($itemId, $yotpoSyncTableItemsData, $parentIds, $parentData, $visibleVariants);
+            $apiParam = $this->getApiParams($itemId, $yotpoSyncTableItemsData, $parentItemsIds, $parentData, $visibleVariants);
 
             if (!$apiParam) {
-                $parentProductId = $parentIds[$itemId] ?? 0;
+                $parentProductId = $parentItemsIds[$itemId] ?? 0;
                 if ($parentProductId) {
                     continue;
                 }
@@ -340,7 +340,7 @@ class Processor extends Main
             //push to parentData array if parent product is
             // being the part of current collection
             if (!$visibleVariants) {
-                $parentData = $this->pushParentData((int)$itemId, $tempSqlArray, $parentData, $parentIds);
+                $parentData = $this->pushParentData((int)$itemId, $tempSqlArray, $parentData, $parentItemsIds);
             }
             $syncDataSql = [];
             $syncDataSql[] = $tempSqlArray;
@@ -359,7 +359,7 @@ class Processor extends Main
             $yotpoExistingProducts = $this->processExistData(
                 $externalIds,
                 $parentData,
-                $parentIds,
+                $parentItemsIds,
                 $visibleVariants
             );
             if ($yotpoExistingProducts && $this->isSyncingAsMainEntity()) {

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -238,7 +238,7 @@ class Processor extends Main
 
         $itemsToBeSyncedToYotpo = $items['sync_data'];
         foreach ($itemsToBeSyncedToYotpo as $itemEntityId => $magentoItemData) {
-            $rowId = $magentoItemData['row_id'];
+            $itemRowId = $magentoItemData['row_id'];
             unset($magentoItemData['row_id']);
 
             if ($this->isSyncingAsMainEntity() && $yotpoSyncTableItemsData && array_key_exists($itemEntityId, $yotpoSyncTableItemsData)) {
@@ -249,7 +249,7 @@ class Processor extends Main
                         'attribute_id' => $syncedToYotpoProductAttributeId,
                         'store_id' => $storeId,
                         'value' => 1,
-                        $this->entityIdFieldValue => $rowId
+                        $this->entityIdFieldValue => $itemRowId
                     ];
                     $sqlDataIntTable = [];
                     $sqlDataIntTable[] = $tempSqlDataIntTable;
@@ -301,7 +301,7 @@ class Processor extends Main
                     'attribute_id' => $syncedToYotpoProductAttributeId,
                     'store_id' => $storeId,
                     'value' => 1,
-                    $this->entityIdFieldValue => $rowId
+                    $this->entityIdFieldValue => $itemRowId
                 ];
                 $sqlDataIntTable = [];
                 $sqlDataIntTable[] = $tempSqlDataIntTable;

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -227,7 +227,7 @@ class Processor extends Main
         $syncedToYotpoProductAttributeId = $this->catalogData->getAttributeId(CoreConfig::CATALOG_SYNC_ATTR_CODE);
         $items = $this->manageSyncItems($collectionItems, $visibleVariants);
         $parentItemsIds = $items['parent_ids'];
-        $parentData = $items['parent_data'];
+        $parentItemsData = $items['parent_data'];
         $yotpoSyncTableItemsData = $items['yotpo_data'];
 
         $lastSyncTime = '';
@@ -261,7 +261,7 @@ class Processor extends Main
             }
 
             $yotpoSyncTableItemsData[$itemId]['yotpo_id'];
-            $apiParam = $this->getApiParams($itemId, $yotpoSyncTableItemsData, $parentItemsIds, $parentData, $visibleVariants);
+            $apiParam = $this->getApiParams($itemId, $yotpoSyncTableItemsData, $parentItemsIds, $parentItemsData, $visibleVariants);
 
             if (!$apiParam) {
                 $parentProductId = $parentItemsIds[$itemId] ?? 0;
@@ -340,7 +340,7 @@ class Processor extends Main
             //push to parentData array if parent product is
             // being the part of current collection
             if (!$visibleVariants) {
-                $parentData = $this->pushParentData((int)$itemId, $tempSqlArray, $parentData, $parentItemsIds);
+                $parentItemsData = $this->pushParentData((int)$itemId, $tempSqlArray, $parentItemsData, $parentItemsIds);
             }
             $syncDataSql = [];
             $syncDataSql[] = $tempSqlArray;
@@ -358,7 +358,7 @@ class Processor extends Main
         if ($externalIds) {
             $yotpoExistingProducts = $this->processExistData(
                 $externalIds,
-                $parentData,
+                $parentItemsData,
                 $parentItemsIds,
                 $visibleVariants
             );

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -313,10 +313,8 @@ class Processor extends Main
             if (!$visibleVariants) {
                 $parentItemsData = $this->pushParentData((int)$itemEntityId, $processedSyncDataRecordToUpdate, $parentItemsData, $parentItemsIds);
             }
-            $this->insertOnDuplicate(
-                'yotpo_product_sync',
-                [$processedSyncDataRecordToUpdate]
-            );
+
+            $this->updateSyncTable($processedSyncDataRecordToUpdate);
             $sqlData[] = $processedSyncDataRecordToUpdate;
         }
 
@@ -759,5 +757,12 @@ class Processor extends Main
             'synced_to_yotpo' => $lastSyncTime,
             'response_code' => $responseCode
         ];
+    }
+
+    private function updateSyncTable($syncDataRecord) {
+        $this->insertOnDuplicate(
+            'yotpo_product_sync',
+            [$syncDataRecord]
+        );
     }
 }

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -243,17 +243,10 @@ class Processor extends Main
 
             if ($this->isSyncingAsMainEntity() && $yotpoSyncTableItemsData && array_key_exists($itemEntityId, $yotpoSyncTableItemsData)) {
                 if (!$this->shouldItemBeResynced($yotpoSyncTableItemsData[$itemEntityId])) {
-                    $tempSqlDataIntTable = [
-                        'attribute_id' => $syncedToYotpoProductAttributeId,
-                        'store_id' => $storeId,
-                        'value' => 1,
-                        $this->entityIdFieldValue => $itemRowId
-                    ];
-                    $sqlDataIntTable = [];
-                    $sqlDataIntTable[] = $tempSqlDataIntTable;
+                    $attributeDataToUpdate = $this->prepareAttributeDataToUpdate($storeId, $itemRowId, $syncedToYotpoProductAttributeId);
                     $this->insertOnDuplicate(
                         'catalog_product_entity_int',
-                        $sqlDataIntTable
+                        [$attributeDataToUpdate]
                     );
                     continue;
                 }
@@ -295,18 +288,11 @@ class Processor extends Main
                 $tempSqlArray['yotpo_id_parent'] = $apiParam['yotpo_id_parent'] ?: 0;
             }
             if ($this->coreConfig->canUpdateCustomAttributeForProducts($tempSqlArray['response_code'])) {
-                $tempSqlDataIntTable = [
-                    'attribute_id' => $syncedToYotpoProductAttributeId,
-                    'store_id' => $storeId,
-                    'value' => 1,
-                    $this->entityIdFieldValue => $itemRowId
-                ];
-                $sqlDataIntTable = [];
-                $sqlDataIntTable[] = $tempSqlDataIntTable;
+                $attributeDataToUpdate = $this->prepareAttributeDataToUpdate($storeId, $itemRowId, $syncedToYotpoProductAttributeId);
                 if ($this->isSyncingAsMainEntity()) {
                     $this->insertOnDuplicate(
                         'catalog_product_entity_int',
-                        $sqlDataIntTable
+                        [$attributeDataToUpdate]
                     );
                 }
             }
@@ -758,5 +744,15 @@ class Processor extends Main
     private function shouldItemBeResynced($yotpoSyncTableItemData)
     {
         return $this->coreConfig->canResync($yotpoSyncTableItemData['response_code'], $yotpoSyncTableItemData, $this->isCommandLineSync);
+    }
+
+    private function prepareAttributeDataToUpdate($storeId, $itemRowId, $syncedToYotpoProductAttributeId)
+    {
+        return [
+            'attribute_id' => $syncedToYotpoProductAttributeId,
+            'store_id' => $storeId,
+            'value' => 1,
+            $this->entityIdFieldValue => $itemRowId
+        ];
     }
 }

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -224,7 +224,7 @@ class Processor extends Main
             return;
         }
 
-        $attributeId = $this->catalogData->getAttributeId(CoreConfig::CATALOG_SYNC_ATTR_CODE);
+        $syncedToYotpoProductAttributeId = $this->catalogData->getAttributeId(CoreConfig::CATALOG_SYNC_ATTR_CODE);
         $items = $this->manageSyncItems($collectionItems, $visibleVariants);
         $parentIds = $items['parent_ids'];
         $yotpoData = $items['yotpo_data'];
@@ -245,7 +245,7 @@ class Processor extends Main
                     $yotpoData[$itemId],
                     $this->isCommandLineSync)) {
                     $tempSqlDataIntTable = [
-                        'attribute_id' => $attributeId,
+                        'attribute_id' => $syncedToYotpoProductAttributeId,
                         'store_id' => $storeId,
                         'value' => 1,
                         $this->entityIdFieldValue => $rowId
@@ -297,7 +297,7 @@ class Processor extends Main
             }
             if ($this->coreConfig->canUpdateCustomAttributeForProducts($tempSqlArray['response_code'])) {
                 $tempSqlDataIntTable = [
-                    'attribute_id' => $attributeId,
+                    'attribute_id' => $syncedToYotpoProductAttributeId,
                     'store_id' => $storeId,
                     'value' => 1,
                     $this->entityIdFieldValue => $rowId

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -242,9 +242,7 @@ class Processor extends Main
             unset($magentoItemData['row_id']);
 
             if ($this->isSyncingAsMainEntity() && $yotpoSyncTableItemsData && array_key_exists($itemEntityId, $yotpoSyncTableItemsData)) {
-                if (!$this->coreConfig->canResync($yotpoSyncTableItemsData[$itemEntityId]['response_code'],
-                    $yotpoSyncTableItemsData[$itemEntityId],
-                    $this->isCommandLineSync)) {
+                if (!$this->shouldItemBeResynced($yotpoSyncTableItemsData[$itemEntityId])) {
                     $tempSqlDataIntTable = [
                         'attribute_id' => $syncedToYotpoProductAttributeId,
                         'store_id' => $storeId,
@@ -755,5 +753,10 @@ class Processor extends Main
             $itemsMap[$product->getId()] = $product;
         }
         return $this->syncDataMain->getProductIds($productIds, $storeId, $itemsMap);
+    }
+
+    private function shouldItemBeResynced($yotpoSyncTableItemData)
+    {
+        return $this->coreConfig->canResync($yotpoSyncTableItemData['response_code'], $yotpoSyncTableItemData, $this->isCommandLineSync);
     }
 }

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -9,6 +9,7 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\App\Emulation as AppEmulation;
 use Yotpo\Core\Model\AbstractJobs;
 use Yotpo\Core\Model\Config as CoreConfig;
+use Yotpo\Core\Model\Sync\Catalog\Data as CatalogData;
 use Yotpo\Core\Model\Sync\Catalog\Logger as YotpoCoreCatalogLogger;
 use Yotpo\Core\Model\Sync\Catalog\YotpoResource;
 use Yotpo\Core\Model\Api\Sync as CoreSync;
@@ -44,6 +45,11 @@ class Main extends AbstractJobs
     protected $coreSync;
 
     /**
+     * @var CatalogData
+     */
+    protected $catalogData;
+
+    /**
      * @var null|int
      */
     protected $productSyncLimit = null;
@@ -72,6 +78,7 @@ class Main extends AbstractJobs
      * @param YotpoResource $yotpoResource
      * @param CollectionFactory $collectionFactory
      * @param CoreSync $coreSync
+     * @param CatalogData $catalogData
      */
     public function __construct(
         AppEmulation $appEmulation,
@@ -80,13 +87,15 @@ class Main extends AbstractJobs
         YotpoCoreCatalogLogger $yotpoCatalogLogger,
         YotpoResource $yotpoResource,
         CollectionFactory $collectionFactory,
-        CoreSync $coreSync
+        CoreSync $coreSync,
+        CatalogData $catalogData
     ) {
         $this->coreConfig = $coreConfig;
         $this->yotpoCatalogLogger = $yotpoCatalogLogger;
         $this->yotpoResource = $yotpoResource;
         $this->collectionFactory = $collectionFactory;
         $this->coreSync = $coreSync;
+        $this->catalogData = $catalogData;
         $this->entityIdFieldValue = $this->coreConfig->getEavRowIdFieldName();
         parent::__construct($appEmulation, $resourceConnection);
     }
@@ -103,8 +112,14 @@ class Main extends AbstractJobs
         switch ($params['method']) {
             case $this->coreConfig->getProductSyncMethod('createProduct'):
             default:
-                $data = ['product' => $data, 'entityLog' => 'catalog'];
-                $response = $this->coreSync->sync('POST', $params['url'], $data);
+                $requestData = ['product' => $data, 'entityLog' => 'catalog'];
+                $response = $this->coreSync->sync('POST', $params['url'], $requestData);
+
+                $productResponseStatusCode = $response->getData('status');
+                if ($productResponseStatusCode == CoreConfig::BAD_REQUEST_RESPONSE_CODE && !$this->isSyncingAsMainEntity()) {
+                    $requestData['product'] = $this->catalogData->getMinimalProductRequestData($data);
+                    $response = $this->coreSync->sync('POST', $params['url'], $requestData);
+                }
                 break;
             case $this->coreConfig->getProductSyncMethod('updateProduct'):
             case $this->coreConfig->getProductSyncMethod('deleteProduct'):
@@ -612,5 +627,13 @@ class Main extends AbstractJobs
     public function setNormalSyncFlag($flag)
     {
         $this->normalSync = $flag;
+    }
+
+    /**
+     * @return boolean
+     */
+    protected function isSyncingAsMainEntity()
+    {
+        return $this->normalSync;
     }
 }

--- a/Model/Sync/Data/Main.php
+++ b/Model/Sync/Data/Main.php
@@ -74,6 +74,7 @@ class Main
     public function getProductIds($productIds, $storeId, $items)
     {
         $productIds = array_unique($productIds);
+
         $connection = $this->resourceConnection->getConnection();
         $table = $this->resourceConnection->getTableName('yotpo_product_sync');
         $products = $connection->select()
@@ -81,6 +82,7 @@ class Main
             ->where('product_id IN(?) ', $productIds)
             ->where('store_id=(?)', $storeId);
         $products = $connection->fetchAssoc($products, []);
+        $existingProductIds = [];
         foreach ($products as $product) {
             $orderItemProduct = $items[$product['product_id']] ?? null;
             $yotpoIdKey = 'yotpo_id';
@@ -93,13 +95,11 @@ class Main
             }
 
             if ($product[$yotpoIdKey]) {
-                $position = array_search($product['product_id'], $productIds);
-                if ($position !== false) {
-                    array_splice($productIds, (int)$position, 1);
-                }
+                $existingProductIds[] = $product['product_id'];
             }
         }
-        return $productIds;
+
+        return array_diff($productIds, $existingProductIds);
     }
 
     /**

--- a/Model/Sync/Data/Main.php
+++ b/Model/Sync/Data/Main.php
@@ -94,7 +94,9 @@ class Main
 
             if ($product[$yotpoIdKey]) {
                 $position = array_search($product['product_id'], $productIds);
-                array_splice($productIds, (int)$position, 1);
+                if ($position !== false) {
+                    array_splice($productIds, (int)$position, 1);
+                }
             }
         }
         return $productIds;

--- a/Model/Sync/Orders/Processor.php
+++ b/Model/Sync/Orders/Processor.php
@@ -165,10 +165,6 @@ class Processor extends Main
         $storeId = $order->getStoreId();
         $this->emulateFrontendArea((int)$storeId);
         $this->currentStoreId = $this->config->getStoreId();
-        if (!$this->config->isOrdersSyncActive()) {
-            $this->stopEnvironmentEmulation();
-            return;
-        }
         $this->yotpoOrdersLogger->info(
             __(
                 'Process order for Magento Store ID: %1, Name: %2',

--- a/Observer/Order/OrderMain.php
+++ b/Observer/Order/OrderMain.php
@@ -59,7 +59,7 @@ class OrderMain
             0
         );
         $this->updateOrderSyncTable($order->getId());
-        if ($this->yotpoConfig->isOrdersSyncActive($order->getStoreId())) {
+        if ($this->yotpoConfig->isRealTimeOrdersSyncActive($order->getStoreId())) {
             $this->ordersProcessor->processOrder($order);
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-core",
     "description": "Yotpo Reviews core extension for Magento2",
-    "version": "4.1.0",
+    "version": "4.1.0.4",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_Core" setup_version="4.1.0" />
+    <module name="Yotpo_Core" setup_version="4.1.0.4" />
 </config>


### PR DESCRIPTION
**Issue 1**
Products sync that was triggered from orders or checkouts sync, never returns an indication that products failed the sync process if an exception was not raised.
This causes us to get 404 responses in the order/checkout creation/update.

**Issue 2**
`getUnSyncedProductIds` returned value does not contain all the unsynced products, when one of the product (or more) does not exist in the Yotpo sync table (`yotpo_products_sync`).
It caused products to not be synced prior to orders/checkouts sync process, which would lead to a 404 exception.

**Issue 3**
Orders real-time sync is not working if orders cron sync is not enabled.