### PR TITLE
COR-1983 Adding fallback for variant without parent in yotpo

### DIFF
--- a/Http/Yclient.php
+++ b/Http/Yclient.php
@@ -33,6 +33,11 @@ class Yclient
     protected $yotpoResponse;
 
     /**
+     * @var YotpoRetry
+     */
+    protected $yotpoRetry;
+
+    /**
      * @var YotpoApiLogger
      */
     protected $yotpoApiLogger;
@@ -47,18 +52,21 @@ class Yclient
      * @param ClientFactory $clientFactory
      * @param ResponseFactory $responseFactory
      * @param YotpoResponse $yotpoResponse
+     * @param YotpoRetry $yotpoRetry
      * @param YotpoApiLogger $yotpoApiLogger
      */
     public function __construct(
         ClientFactory $clientFactory,
         ResponseFactory $responseFactory,
         YotpoResponse $yotpoResponse,
-        YotpoApiLogger $yotpoApiLogger
+        YotpoApiLogger $yotpoApiLogger,
+        YotpoRetry $yotpoRetry
     ) {
         $this->clientFactory = $clientFactory;
         $this->responseFactory = $responseFactory;
         $this->yotpoResponse = $yotpoResponse;
         $this->yotpoApiLogger = $yotpoApiLogger;
+        $this->yotpoRetry = $yotpoRetry;
     }
 
     /**
@@ -133,21 +141,15 @@ class Yclient
         string $method,
         string $baseUrl,
         string $uriEndpoint,
-        Array $options = []
+        Array $options = [],
+        $shouldRetry = false
     ) {
-        $response = $this->doRequest($baseUrl, $uriEndpoint, $options, $method);
-        $status = $response->getStatusCode();
-        $responseBody = $response->getBody();
-        $responseReason = $response->getReasonPhrase();
-        $responseContent = $responseBody->getContents();
-        $this->yotpoApiLogger->info($responseContent, []);
-        $responseBody->rewind();
-        $responseObject = new \Magento\Framework\DataObject();
-        $responseObject->setData('status', $status);
-        $responseObject->setData('is_success', $this->yotpoResponse->validateResponse($responseObject));
-        $responseObject->setData('reason', $responseReason);
-        $responseObject->setData('response', json_decode($responseContent, true));
-        return $responseObject;
+        $requestClosure = $this->buildRequestClosure($baseUrl, $uriEndpoint, $options, $method);
+
+        if ($shouldRetry) {
+            return $this->yotpoRetry->executeRequest($requestClosure);
+        }
+        return $requestClosure();
     }
 
     /**
@@ -174,5 +176,31 @@ class Yclient
         if ($handlerInstance) {
             $this->yotpoApiLogger->setHandlers([$handlerInstance]);
         }
+    }
+
+    /**
+     * @param string $baseUrl
+     * @param string $uriEndpoint
+     * @param array $options
+     * @param string $method
+     * @return \Closure
+     */
+    private function buildRequestClosure(string $baseUrl, string $uriEndpoint, array $options, string $method)
+    {
+        return function () use ($baseUrl, $uriEndpoint, $options, $method) {
+            $response = $this->doRequest($baseUrl, $uriEndpoint, $options, $method);
+            $status = $response->getStatusCode();
+            $responseBody = $response->getBody();
+            $responseReason = $response->getReasonPhrase();
+            $responseContent = $responseBody->getContents();
+            $this->yotpoApiLogger->info($responseContent, []);
+            $responseBody->rewind();
+            $responseObject = new \Magento\Framework\DataObject();
+            $responseObject->setData('status', $status);
+            $responseObject->setData('is_success', $this->yotpoResponse->validateResponse($responseObject));
+            $responseObject->setData('reason', $responseReason);
+            $responseObject->setData('response', json_decode($responseContent, true));
+            return $responseObject;
+        };
     }
 }

--- a/Http/Yclient.php
+++ b/Http/Yclient.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\ResponseFactory;
 use Magento\Framework\Webapi\Rest\Request;
 use Yotpo\Core\Model\Api\Logger as YotpoApiLogger;
+use Yotpo\Core\Model\Api\Response as YotpoResponse;
 
 /**
  * Class Yclient to manage API client communication
@@ -27,6 +28,11 @@ class Yclient
     protected $clientFactory;
 
     /**
+     * @var YotpoResponse
+     */
+    protected $yotpoResponse;
+
+    /**
      * @var YotpoApiLogger
      */
     protected $yotpoApiLogger;
@@ -40,15 +46,18 @@ class Yclient
      * Yclient constructor.
      * @param ClientFactory $clientFactory
      * @param ResponseFactory $responseFactory
+     * @param YotpoResponse $yotpoResponse
      * @param YotpoApiLogger $yotpoApiLogger
      */
     public function __construct(
         ClientFactory $clientFactory,
         ResponseFactory $responseFactory,
+        YotpoResponse $yotpoResponse,
         YotpoApiLogger $yotpoApiLogger
     ) {
         $this->clientFactory = $clientFactory;
         $this->responseFactory = $responseFactory;
+        $this->yotpoResponse = $yotpoResponse;
         $this->yotpoApiLogger = $yotpoApiLogger;
     }
 
@@ -135,6 +144,7 @@ class Yclient
         $responseBody->rewind();
         $responseObject = new \Magento\Framework\DataObject();
         $responseObject->setData('status', $status);
+        $responseObject->setData('is_success', $this->yotpoResponse->validateResponse($responseObject));
         $responseObject->setData('reason', $responseReason);
         $responseObject->setData('response', json_decode($responseContent, true));
         return $responseObject;

--- a/Http/YotpoRetry.php
+++ b/Http/YotpoRetry.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Yotpo\Core\Http;
+
+use Magento\Framework\DataObject;
+use Yotpo\Core\Model\Config;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+class YotpoRetry
+{
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    const IS_SUCCESS_KEY = 'is_success';
+    const STATUS_KEY = 'status';
+
+    /**
+     * Processor constructor.
+     * @param Config $config
+     */
+    public function __construct(Config $config) {
+        $this->config = $config;
+    }
+
+    /**
+     * Yotpo retry requests mechanism
+     *
+     * @return DataObject
+     */
+    public function executeRequest($request)
+    {
+        $attemptsLeftCount = $this->getMaxAttemptsAmount();
+
+        $attemptsLeftCount--;
+        $requestResult = $request();
+
+        while ($this->haveAdditionalAttempts($attemptsLeftCount)) {
+            if (!$requestResult->getData(self::IS_SUCCESS_KEY)) {
+                if ($this->config->isNetworkRetriableResponse($requestResult->getData(self::STATUS_KEY))) {
+                    sleep(1);
+                    $attemptsLeftCount--;
+                    $requestResult = $request();
+                }
+            } else {
+                break;
+            }
+        }
+
+        return $requestResult;
+    }
+
+    /**
+     * @param $attemptsLeftCount
+     * @return bool
+     */
+    private function haveAdditionalAttempts($attemptsLeftCount)
+    {
+        return $attemptsLeftCount > 0;
+    }
+
+    /**
+     * @return int
+     */
+    private function getMaxAttemptsAmount()
+    {
+        return $this->config->getYotpoRetryAttemptsAmount();
+    }
+}

--- a/Model/Api/Request.php
+++ b/Model/Api/Request.php
@@ -87,13 +87,12 @@ class Request
         }
         $options['headers'] = $this->prepareHeaders();
         $response = $this->yotpoHttpclient->send($method, $baseUrl, $endPoint, $options);
-        $successFullResponse = $this->yotpoResponse->validateResponse($response);
+        $successFullResponse = $response->getData('is_success');
         if (!$successFullResponse && $this->yotpoResponse->invalidToken($response) && $this->retryRequestInvalidToken) {
             $this->getAuthToken(true); //generate new token
             $this->retryRequestInvalidToken--;
             $this->send($method, $endPoint, $data);
         }
-        $response->setData('is_success', $successFullResponse);
         return $response;
     }
 

--- a/Model/Api/Request.php
+++ b/Model/Api/Request.php
@@ -70,7 +70,8 @@ class Request
         string $method,
         string $endPoint,
         array $data = [],
-        string $baseUrlKey = 'api'
+        string $baseUrlKey = 'api',
+        $shouldRetry = false
     ): DataObject {
         $appKey = $this->config->getConfig('app_key');
         $baseUrl = str_ireplace('{store_id}', $appKey, $this->config->getConfig($baseUrlKey));
@@ -86,7 +87,7 @@ class Request
             $options['json']    =   $data;
         }
         $options['headers'] = $this->prepareHeaders();
-        $response = $this->yotpoHttpclient->send($method, $baseUrl, $endPoint, $options);
+        $response = $this->yotpoHttpclient->send($method, $baseUrl, $endPoint, $options, $shouldRetry);
         $successFullResponse = $response->getData('is_success');
         if (!$successFullResponse && $this->yotpoResponse->invalidToken($response) && $this->retryRequestInvalidToken) {
             $this->getAuthToken(true); //generate new token

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -26,6 +26,8 @@ class Config
 
     const UPDATE_SQL_LIMIT = 50000;
 
+    const YOTPO_RETRY_ATTEMPTS_AMOUNT = 3;
+
     const MODULE_NAME = 'Yotpo_Core';
 
     /**
@@ -663,5 +665,13 @@ class Config
     public function getUpdateSqlLimit(): int
     {
         return self::UPDATE_SQL_LIMIT;
+    }
+
+    /**
+     * @return int
+     */
+    public function getYotpoRetryAttemptsAmount(): int
+    {
+        return self::YOTPO_RETRY_ATTEMPTS_AMOUNT;
     }
 }

--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -190,11 +190,11 @@ class Data extends Main
 
     /**
      * @param array <mixed> $items
-     * @param boolean $visibleVariants
+     * @param boolean $isVariantsDataIncluded
      * @return array <mixed>
      * @throws NoSuchEntityException
      */
-    public function manageSyncItems($items, $visibleVariants = false)
+    public function manageSyncItems($items, $isVariantsDataIncluded = false)
     {
         $return = [
             'sync_data' => [],
@@ -210,7 +210,7 @@ class Data extends Main
         }
         $visibleVariantsData = [];
         $parentIds = [];
-        if (!$visibleVariants) {
+        if (!$isVariantsDataIncluded) {
             $configIds = $this->yotpoResource->getConfigProductIds($productsId);
             $syncItems = $this->mergeProductOptions($syncItems, $configIds, $productsObject);
             $groupIds = $this->yotpoResource->getGroupProductIds($productsId);

--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -194,7 +194,7 @@ class Data extends Main
      * @return array <mixed>
      * @throws NoSuchEntityException
      */
-    public function getSyncItems($items, $isVariantsDataIncluded = false)
+    public function getSyncItems($items, $isVariantsDataIncluded)
     {
         $return = [
             'sync_data' => [],

--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -194,7 +194,7 @@ class Data extends Main
      * @return array <mixed>
      * @throws NoSuchEntityException
      */
-    public function manageSyncItems($items, $isVariantsDataIncluded = false)
+    public function getSyncItems($items, $isVariantsDataIncluded = false)
     {
         $return = [
             'sync_data' => [],

--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -329,7 +329,7 @@ class Data extends Main
      * @return array<string, string|array>
      * @throws NoSuchEntityException
      */
-    protected function attributeMapping(Product $item)
+    public function attributeMapping(Product $item)
     {
         $itemArray = [];
         $mapAttributes = $this->mappingAttributes;

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -214,15 +214,15 @@ class Processor extends Main
     /**
      * @param array <mixed> $collectionItems
      * @param int $storeId
-     * @param boolean $visibleVariants
+     * @param boolean $isVisibleVariantsSync
      * @return void
      * @throws NoSuchEntityException
      */
-    public function syncItems($collectionItems, $storeId, $visibleVariants = false)
+    public function syncItems($collectionItems, $storeId, $isVisibleVariantsSync = false)
     {
         if (count($collectionItems)) {
             $attributeId = $this->catalogData->getAttributeId(CoreConfig::CATALOG_SYNC_ATTR_CODE);
-            $items = $this->manageSyncItems($collectionItems, $visibleVariants);
+            $items = $this->manageSyncItems($collectionItems, $isVisibleVariantsSync);
             $parentIds = $items['parent_ids'];
             $yotpoData = $items['yotpo_data'];
             $parentData = $items['parent_data'];
@@ -230,7 +230,7 @@ class Processor extends Main
             $lastSyncTime = '';
             $sqlData = $sqlDataIntTable = [];
             $externalIds = [];
-            $visibleVariantsData = $visibleVariants ? [] : $items['visible_variants'];
+            $visibleVariantsData = $isVisibleVariantsSync ? [] : $items['visible_variants'];
             $visibleVariantsDataValues = array_values($visibleVariantsData);
 
             foreach ($items['sync_data'] as $itemId => $itemData) {
@@ -262,7 +262,7 @@ class Processor extends Main
                     continue;
                 }
 
-                $apiParam = $this->getApiParams($itemId, $yotpoData, $parentIds, $parentData, $visibleVariants);
+                $apiParam = $this->getApiParams($itemId, $yotpoData, $parentIds, $parentData, $isVisibleVariantsSync);
 
                 if (!$apiParam) {
                     $parentProductId = $parentIds[$itemId] ?? 0;
@@ -282,7 +282,7 @@ class Processor extends Main
                 $response = $this->processRequest($apiParam, $itemData);
 
                 $lastSyncTime = $this->getCurrentTime();
-                $yotpoIdKey = $visibleVariants ? 'visible_variant_yotpo_id' : 'yotpo_id';
+                $yotpoIdKey = $isVisibleVariantsSync ? 'visible_variant_yotpo_id' : 'yotpo_id';
                 $tempSqlArray = [
                     'product_id' => $itemId,
                     $yotpoIdKey => $apiParam['yotpo_id'] ?: 0,
@@ -291,7 +291,7 @@ class Processor extends Main
                     'response_code' => $response->getData('status'),
                     'sync_status' => 1
                 ];
-                if (!$visibleVariants) {
+                if (!$isVisibleVariantsSync) {
                     $tempSqlArray['yotpo_id_parent'] = $apiParam['yotpo_id_parent'] ?: 0;
                 }
                 if ($this->coreConfig->canUpdateCustomAttributeForProducts($tempSqlArray['response_code'])) {
@@ -317,7 +317,7 @@ class Processor extends Main
                     $tempSqlArray,
                     $itemData,
                     $externalIds,
-                    $visibleVariants
+                    $isVisibleVariantsSync
                 );
 
                 $tempSqlArray = $returnResponse['temp_sql'];
@@ -329,8 +329,8 @@ class Processor extends Main
 
                 if (count($returnResponse['four_not_four_data'])) {
                     foreach ($returnResponse['four_not_four_data'] as $retryId) {
-                        if ($this->isImmediateRetry($response, $this->entity, $visibleVariants.$retryId, $storeId)) {
-                            $this->setImmediateRetryAlreadyDone($this->entity, $visibleVariants.$retryId, $storeId);
+                        if ($this->isImmediateRetry($response, $this->entity, $isVisibleVariantsSync.$retryId, $storeId)) {
+                            $this->setImmediateRetryAlreadyDone($this->entity, $isVisibleVariantsSync.$retryId, $storeId);
                             $this->retryItems[$storeId][$retryId] = $retryId;
                         }
                     }
@@ -338,7 +338,7 @@ class Processor extends Main
 
                 //push to parentData array if parent product is
                 // being the part of current collection
-                if (!$visibleVariants) {
+                if (!$isVisibleVariantsSync) {
                     $parentData = $this->pushParentData((int)$itemId, $tempSqlArray, $parentData, $parentIds);
                 }
                 $syncDataSql = [];
@@ -363,7 +363,7 @@ class Processor extends Main
                     $externalIds,
                     $parentData,
                     $parentIds,
-                    $visibleVariants
+                    $isVisibleVariantsSync
                 );
                 if ($yotpoExistingProducts && $this->normalSync) {
                     $dataToSent = array_merge(
@@ -376,7 +376,7 @@ class Processor extends Main
             if ($this->normalSync) {
                 $this->coreConfig->saveConfig('catalog_last_sync_time', $lastSyncTime);
                 $dataForCategorySync = [];
-                if ($dataToSent && !$visibleVariants) {
+                if ($dataToSent && !$isVisibleVariantsSync) {
                     $dataForCategorySync = $this->getProductsForCategorySync(
                         $dataToSent,
                         $collectionItems,
@@ -388,7 +388,7 @@ class Processor extends Main
                 }
             }
 
-            $reSyncYotpoKey = $visibleVariants ? 'visible_variant_yotpo_id' : 'yotpo_id';
+            $reSyncYotpoKey = $isVisibleVariantsSync ? 'visible_variant_yotpo_id' : 'yotpo_id';
             if (isset($this->retryItems[$storeId]) && count($this->retryItems[$storeId]) > 0) {
                 $this->update(
                     'yotpo_product_sync',
@@ -397,10 +397,10 @@ class Processor extends Main
                 );
                 $collection = $this->getCollectionForSync($this->retryItems[$storeId]);
                 $this->isImmediateRetry = true;
-                $this->syncItems($collection->getItems(), $storeId, $visibleVariants);
+                $this->syncItems($collection->getItems(), $storeId, $isVisibleVariantsSync);
             }
 
-            if ($visibleVariantsDataValues && !$visibleVariants) {
+            if ($visibleVariantsDataValues && !$isVisibleVariantsSync) {
                 $this->syncItems($visibleVariantsDataValues, $storeId, true);
             }
         } else {

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -518,7 +518,7 @@ class Processor extends Main
      * @return array <mixed>
      * @throws NoSuchEntityException
      */
-    protected function getSyncItems($items, $isVariantsDataIncluded = false): array
+    protected function getSyncItems($items, $isVariantsDataIncluded): array
     {
         return $this->catalogData->getSyncItems($items, $isVariantsDataIncluded);
     }

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -514,13 +514,13 @@ class Processor extends Main
 
     /**
      * @param array <mixed> $items
-     * @param boolean $visibleVariants
+     * @param boolean $isVariantsDataIncluded
      * @return array <mixed>
      * @throws NoSuchEntityException
      */
-    protected function manageSyncItems($items, $visibleVariants = false): array
+    protected function manageSyncItems($items, $isVariantsDataIncluded = false): array
     {
-        return $this->catalogData->manageSyncItems($items, $visibleVariants);
+        return $this->catalogData->manageSyncItems($items, $isVariantsDataIncluded);
     }
 
     /**

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -222,7 +222,7 @@ class Processor extends Main
     {
         if (count($collectionItems)) {
             $attributeId = $this->catalogData->getAttributeId(CoreConfig::CATALOG_SYNC_ATTR_CODE);
-            $items = $this->manageSyncItems($collectionItems, $isVisibleVariantsSync);
+            $items = $this->getSyncItems($collectionItems, $isVisibleVariantsSync);
             $parentIds = $items['parent_ids'];
             $yotpoData = $items['yotpo_data'];
             $parentData = $items['parent_data'];
@@ -518,9 +518,9 @@ class Processor extends Main
      * @return array <mixed>
      * @throws NoSuchEntityException
      */
-    protected function manageSyncItems($items, $isVariantsDataIncluded = false): array
+    protected function getSyncItems($items, $isVariantsDataIncluded = false): array
     {
-        return $this->catalogData->manageSyncItems($items, $isVariantsDataIncluded);
+        return $this->catalogData->getSyncItems($items, $isVariantsDataIncluded);
     }
 
     /**

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -359,8 +359,9 @@ class Main extends AbstractJobs
             $yotpoIdKey = 'visible_variant_yotpo_id';
         } elseif (count($parentIds) && isset($parentIds[$productId])) {
             $parentId = $parentIds[$productId];
-            if (is_array($this->setProductVariantRequest($parentData, $parentId, $method, $apiUrl))) {
-                return [];
+
+            if ($this->isProductParentYotpoIdFound($parentData, $parentId)) {
+                $this->setProductVariantRequest($parentData, $parentId, $method, $apiUrl);
             }
         }
 
@@ -625,17 +626,13 @@ class Main extends AbstractJobs
      */
     private function setProductVariantRequest($parentData, $parentId, &$method, &$apiUrl)
     {
-        if ($this->isProductParentYotpoIdFound($parentData, $parentId)) {
-            $yotpoIdParent = $parentData[$parentId]['yotpo_id'];
+        $yotpoIdParent = $parentData[$parentId]['yotpo_id'];
 
-            $method = $this->coreConfig->getProductSyncMethod('createProductVariant');
-            $apiUrl = $this->coreConfig->getEndpoint(
-                'variant',
-                ['{yotpo_product_id}'],
-                [$yotpoIdParent]
-            );
-        } else {
-            return [];
-        }
+        $method = $this->coreConfig->getProductSyncMethod('createProductVariant');
+        $apiUrl = $this->coreConfig->getEndpoint(
+            'variant',
+            ['{yotpo_product_id}'],
+            [$yotpoIdParent]
+        );
     }
 }

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -357,19 +357,9 @@ class Main extends AbstractJobs
 
         if ($isVisibleVariant) {
             $yotpoIdKey = 'visible_variant_yotpo_id';
-        } else {
-            if (count($parentIds) && isset($parentIds[$productId])
-                && isset($parentData[$parentIds[$productId]])
-                && isset($parentData[$parentIds[$productId]]['yotpo_id'])
-                && $yotpoIdParent = $parentData[$parentIds[$productId]]['yotpo_id']) {
-
-                $method = $this->coreConfig->getProductSyncMethod('createProductVariant');
-                $apiUrl = $this->coreConfig->getEndpoint(
-                    'variant',
-                    ['{yotpo_product_id}'],
-                    [$yotpoIdParent]
-                );
-            } elseif (isset($parentIds[$productId])) {
+        } elseif (count($parentIds) && isset($parentIds[$productId])) {
+            $parentId = $parentIds[$productId];
+            if (is_array($this->setProductVariantRequest($parentData, $parentId, $method, $apiUrl))) {
                 return [];
             }
         }
@@ -614,5 +604,29 @@ class Main extends AbstractJobs
     public function setNormalSyncFlag($flag)
     {
         $this->normalSync = $flag;
+    }
+
+    /**
+     * @param array $parentData
+     * @param string $parentId
+     * @param string &$method
+     * @param string &$apiUrl
+     * @return array|void
+     */
+    private function setProductVariantRequest($parentData, $parentId, &$method, &$apiUrl)
+    {
+        if (isset($parentData[$parentId])
+            && isset($parentData[$parentId]['yotpo_id'])
+            && $yotpoIdParent = $parentData[$parentId]['yotpo_id']) {
+
+            $method = $this->coreConfig->getProductSyncMethod('createProductVariant');
+            $apiUrl = $this->coreConfig->getEndpoint(
+                'variant',
+                ['{yotpo_product_id}'],
+                [$yotpoIdParent]
+            );
+        } else {
+            return [];
+        }
     }
 }

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -339,7 +339,7 @@ class Main extends AbstractJobs
      * @param array<int, array> $yotpoData
      * @param array<int, int> $parentIds
      * @param array<int|string, mixed> $parentData
-     * @param boolean $visibleVariants
+     * @param boolean $isVisibleVariant
      * @return array<string, string>
      * @throws NoSuchEntityException
      */
@@ -348,13 +348,13 @@ class Main extends AbstractJobs
         array $yotpoData,
         array $parentIds,
         array $parentData,
-        $visibleVariants = false
+        $isVisibleVariant
     ) {
         $apiUrl = $this->coreConfig->getEndpoint('products');
         $method = $this->coreConfig->getProductSyncMethod('createProduct');
         $yotpoIdParent = $yotpoId = '';
 
-        if (count($parentIds) && !$visibleVariants) {
+        if (count($parentIds) && !$isVisibleVariant) {
             if (isset($parentIds[$productId])
                 && isset($parentData[$parentIds[$productId]])
                 && isset($parentData[$parentIds[$productId]]['yotpo_id'])
@@ -371,7 +371,7 @@ class Main extends AbstractJobs
             }
         }
 
-        $yotpoIdKey = $visibleVariants ? 'visible_variant_yotpo_id' : 'yotpo_id';
+        $yotpoIdKey = $isVisibleVariant ? 'visible_variant_yotpo_id' : 'yotpo_id';
         if (count($yotpoData)) {
             if (isset($yotpoData[$productId])
                 && isset($yotpoData[$productId][$yotpoIdKey])

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -607,6 +607,16 @@ class Main extends AbstractJobs
     }
 
     /**
+     * @param $parentData
+     * @param $parentId
+     * @return bool
+     */
+    public function isProductParentYotpoIdFound($parentData, $parentId): bool
+    {
+        return isset($parentData[$parentId]) && isset($parentData[$parentId]['yotpo_id']);
+    }
+
+    /**
      * @param array $parentData
      * @param string $parentId
      * @param string &$method
@@ -615,9 +625,8 @@ class Main extends AbstractJobs
      */
     private function setProductVariantRequest($parentData, $parentId, &$method, &$apiUrl)
     {
-        if (isset($parentData[$parentId])
-            && isset($parentData[$parentId]['yotpo_id'])
-            && $yotpoIdParent = $parentData[$parentId]['yotpo_id']) {
+        if ($this->isProductParentYotpoIdFound($parentData, $parentId)) {
+            $yotpoIdParent = $parentData[$parentId]['yotpo_id'];
 
             $method = $this->coreConfig->getProductSyncMethod('createProductVariant');
             $apiUrl = $this->coreConfig->getEndpoint(

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -353,9 +353,12 @@ class Main extends AbstractJobs
         $apiUrl = $this->coreConfig->getEndpoint('products');
         $method = $this->coreConfig->getProductSyncMethod('createProduct');
         $yotpoIdParent = $yotpoId = '';
+        $yotpoIdKey = 'yotpo_id';
 
-        if (count($parentIds) && !$isVisibleVariant) {
-            if (isset($parentIds[$productId])
+        if ($isVisibleVariant) {
+            $yotpoIdKey = 'visible_variant_yotpo_id';
+        } else {
+            if (count($parentIds) && isset($parentIds[$productId])
                 && isset($parentData[$parentIds[$productId]])
                 && isset($parentData[$parentIds[$productId]]['yotpo_id'])
                 && $yotpoIdParent = $parentData[$parentIds[$productId]]['yotpo_id']) {
@@ -371,7 +374,6 @@ class Main extends AbstractJobs
             }
         }
 
-        $yotpoIdKey = $isVisibleVariant ? 'visible_variant_yotpo_id' : 'yotpo_id';
         if (count($yotpoData)) {
             if (isset($yotpoData[$productId])
                 && isset($yotpoData[$productId][$yotpoIdKey])

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-core",
     "description": "Yotpo Reviews core extension for Magento2",
-    "version": "4.0.18",
+    "version": "4.1.0",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_Core" setup_version="4.0.18" />
+    <module name="Yotpo_Core" setup_version="4.1.0" />
 </config>


### PR DESCRIPTION
## Issue:
Variants (simple non-visible products - grouped or configurable) are not being synced to Yotpo when their parent product was not synced to Yotpo yet. The sync fails.
Since the sync works in batches, if there are many cases like this - the state is unrecoverable.
This issue has effect on catalog sync as well as orders/checkouts sync.

## Developer Notes
This is not PR ready. This on the table solution for variant without parent in Yotpo solution.
This PR is based on this refactoring [branch](https://github.com/YotpoLtd/magento2-module-core/pull/113)
This PR also should also be merged it will be merged after this [PR](https://github.com/YotpoLtd/magento2-module-core/pull/99) for minimal product creation fallback.

