### PR TITLE
COR-FIX realtime order was not synced if cron was not enabled

### DIFF
--- a/Model/Sync/Orders/Processor.php
+++ b/Model/Sync/Orders/Processor.php
@@ -165,10 +165,6 @@ class Processor extends Main
         $storeId = $order->getStoreId();
         $this->emulateFrontendArea((int)$storeId);
         $this->currentStoreId = $this->config->getStoreId();
-        if (!$this->config->isOrdersSyncActive()) {
-            $this->stopEnvironmentEmulation();
-            return;
-        }
         $this->yotpoOrdersLogger->info(
             __(
                 'Process order for Magento Store ID: %1, Name: %2',

--- a/Observer/Order/OrderMain.php
+++ b/Observer/Order/OrderMain.php
@@ -59,7 +59,7 @@ class OrderMain
             0
         );
         $this->updateOrderSyncTable($order->getId());
-        if ($this->yotpoConfig->isOrdersSyncActive($order->getStoreId())) {
+        if ($this->yotpoConfig->isRealTimeOrdersSyncActive($order->getStoreId())) {
             $this->ordersProcessor->processOrder($order);
         }
     }


### PR DESCRIPTION
**Issue:**
Orders real-time sync is not working if the batch sync is not enabled.