### PR TITLE
COR-FIX Sync/Data/Main#getProductIds removed missing products

### DIFF
--- a/Model/Sync/Data/Main.php
+++ b/Model/Sync/Data/Main.php
@@ -74,6 +74,7 @@ class Main
     public function getProductIds($productIds, $storeId, $items)
     {
         $productIds = array_unique($productIds);
+
         $connection = $this->resourceConnection->getConnection();
         $table = $this->resourceConnection->getTableName('yotpo_product_sync');
         $products = $connection->select()
@@ -81,6 +82,8 @@ class Main
             ->where('product_id IN(?) ', $productIds)
             ->where('store_id=(?)', $storeId);
         $products = $connection->fetchAssoc($products, []);
+
+        $existingProductIds = [];
         foreach ($products as $product) {
             $orderItemProduct = $items[$product['product_id']] ?? null;
             $yotpoIdKey = 'yotpo_id';
@@ -93,11 +96,11 @@ class Main
             }
 
             if ($product[$yotpoIdKey]) {
-                $position = array_search($product['product_id'], $productIds);
-                array_splice($productIds, (int)$position, 1);
+                $existingProductIds[] = $product['product_id'];
             }
         }
-        return $productIds;
+
+        return array_diff($productIds, $existingProductIds);
     }
 
     /**


### PR DESCRIPTION
**Issue**
`getUnSyncedProductIds` returned value does not contain all the unsynced products, when one of the product (or more) does not exist in the Yotpo sync table (`yotpo_products_sync`).
It caused products to not be synced prior to orders/checkouts sync process, which would lead to a 404 exception.

Moved into https://github.com/YotpoLtd/magento2-module-core/pull/128
