### PR TITLE
Fix Orders sync stuck on long loop

### DIFF
--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -724,6 +724,7 @@ class Processor extends Main
         $unSyncedProductIds = $this->getUnSyncedProductIds($productIds, $visibleItems, $storeId);
         if ($unSyncedProductIds) {
             $this->setNormalSyncFlag(false);
+            $unSyncedProductIds = [$storeId => $unSyncedProductIds];
             $sync = $this->process($unSyncedProductIds, [$storeId]);
             $this->emulateFrontendArea($storeId);
             return $sync;


### PR DESCRIPTION
The orders sync triggered the catalog sync, which in turn triggered the catalog process with a wrong argument type.

Tryzens source PR: https://github.com/YotpoLtd/magento2-module-core/pull/115/files