### PR TITLE
COR-1983 Adding fallback for variant without parent sync to yotpo

### DIFF
--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -190,11 +190,11 @@ class Data extends Main
 
     /**
      * @param array <mixed> $items
-     * @param boolean $visibleVariants
+     * @param boolean $isVariantsDataIncluded
      * @return array <mixed>
      * @throws NoSuchEntityException
      */
-    public function manageSyncItems($items, $visibleVariants = false)
+    public function manageSyncItems($items, $isVariantsDataIncluded = false)
     {
         $return = [
             'sync_data' => [],
@@ -210,7 +210,7 @@ class Data extends Main
         }
         $visibleVariantsData = [];
         $parentIds = [];
-        if (!$visibleVariants) {
+        if (!$isVariantsDataIncluded) {
             $configIds = $this->yotpoResource->getConfigProductIds($productsId);
             $syncItems = $this->mergeProductOptions($syncItems, $configIds, $productsObject);
             $groupIds = $this->yotpoResource->getGroupProductIds($productsId);

--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -194,7 +194,7 @@ class Data extends Main
      * @return array <mixed>
      * @throws NoSuchEntityException
      */
-    public function getSyncItems($items, $isVariantsDataIncluded = false)
+    public function getSyncItems($items, $isVariantsDataIncluded)
     {
         $return = [
             'sync_data' => [],

--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -194,7 +194,7 @@ class Data extends Main
      * @return array <mixed>
      * @throws NoSuchEntityException
      */
-    public function manageSyncItems($items, $isVariantsDataIncluded = false)
+    public function getSyncItems($items, $isVariantsDataIncluded = false)
     {
         $return = [
             'sync_data' => [],

--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -198,8 +198,8 @@ class Data extends Main
     {
         $return = [
             'sync_data' => [],
-            'parent_ids' => [],
-            'parent_data' => []
+            'parents_ids' => [],
+            'parents_data' => []
         ];
         $syncItems = $productsId = $productsObject = [];
         foreach ($items as $item) {
@@ -223,10 +223,10 @@ class Data extends Main
             }
         }
         $return['sync_data'] = $syncItems;
-        $return['parent_ids'] = $parentIds;
+        $return['parents_ids'] = $parentIds;
         $yotpoData = $this->fetchYotpoData($productsId, $parentIds);
         $return['yotpo_data'] = $yotpoData['yotpo_data'];
-        $return['parent_data'] = $yotpoData['parent_data'];
+        $return['parents_data'] = $yotpoData['parents_data'];
         $return['visible_variants'] = $visibleVariantsData;
         return $return;
     }

--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -329,7 +329,7 @@ class Data extends Main
      * @return array<string, string|array>
      * @throws NoSuchEntityException
      */
-    protected function attributeMapping(Product $item)
+    public function attributeMapping(Product $item)
     {
         $itemArray = [];
         $mapAttributes = $this->mappingAttributes;

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -248,11 +248,12 @@ class Processor extends Main
             $itemRowId = $yotpoFormatItemData['row_id'];
             unset($yotpoFormatItemData['row_id']);
 
+            $attributeDataToUpdate = $this->prepareAttributeDataToUpdate($storeId, $itemRowId, $syncedToYotpoProductAttributeId);
+
             if ($yotpoSyncTableItemsData
                 && array_key_exists($itemEntityId, $yotpoSyncTableItemsData)
                 && !$this->shouldItemBeResynced($yotpoSyncTableItemsData[$itemEntityId])
             ) {
-                $attributeDataToUpdate = $this->prepareAttributeDataToUpdate($storeId, $itemRowId, $syncedToYotpoProductAttributeId);
                 if ($this->isSyncingAsMainEntity()) {
                     $this->insertOnDuplicate(
                         'catalog_product_entity_int',
@@ -295,7 +296,6 @@ class Processor extends Main
                 $tempSqlArray['yotpo_id_parent'] = $apiParam['yotpo_id_parent'] ?: 0;
             }
             if ($this->coreConfig->canUpdateCustomAttributeForProducts($tempSqlArray['response_code'])) {
-                $attributeDataToUpdate = $this->prepareAttributeDataToUpdate($storeId, $itemRowId, $syncedToYotpoProductAttributeId);
                 if ($this->isSyncingAsMainEntity()) {
                     $this->insertOnDuplicate(
                         'catalog_product_entity_int',

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -250,11 +250,7 @@ class Processor extends Main
 
             if ($yotpoSyncTableItemsData
                 && array_key_exists($itemEntityId, $yotpoSyncTableItemsData)
-                && !$this->coreConfig->canResync(
-                    $yotpoSyncTableItemsData[$itemEntityId]['response_code'],
-                    $yotpoSyncTableItemsData[$itemEntityId],
-                    $this->isCommandLineSync
-                )
+                && !$this->shouldItemBeResynced($yotpoSyncTableItemsData[$itemEntityId])
             ) {
                 $tempSqlDataIntTable = [
                     'attribute_id' => $syncedToYotpoProductAttributeId,
@@ -757,5 +753,10 @@ class Processor extends Main
             $itemsMap[$product->getId()] = $product;
         }
         return $this->syncDataMain->getProductIds($productIds, $storeId, $itemsMap);
+    }
+
+    private function shouldItemBeResynced($yotpoSyncTableItemData)
+    {
+        return $this->coreConfig->canResync($yotpoSyncTableItemData['response_code'], $yotpoSyncTableItemData, $this->isCommandLineSync);
     }
 }

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -255,10 +255,7 @@ class Processor extends Main
                 && !$this->shouldItemBeResynced($yotpoSyncTableItemsData[$itemEntityId])
             ) {
                 if ($this->isSyncingAsMainEntity()) {
-                    $this->insertOnDuplicate(
-                        'catalog_product_entity_int',
-                        [$attributeDataToUpdate]
-                    );
+                    $this->updateProductSyncAttribute($attributeDataToUpdate);
                 }
                 continue;
             }
@@ -292,10 +289,7 @@ class Processor extends Main
             }
             if ($this->coreConfig->canUpdateCustomAttributeForProducts($syncDataRecordToUpdate['response_code'])) {
                 if ($this->isSyncingAsMainEntity()) {
-                    $this->insertOnDuplicate(
-                        'catalog_product_entity_int',
-                        [$attributeDataToUpdate]
-                    );
+                    $this->updateProductSyncAttribute($attributeDataToUpdate);
                 }
             }
 
@@ -738,6 +732,13 @@ class Processor extends Main
             'synced_to_yotpo' => $lastSyncTime,
             'response_code' => $responseCode
         ];
+    }
+
+    private function updateProductSyncAttribute($attributeDataToUpdate) {
+        $this->insertOnDuplicate(
+            'catalog_product_entity_int',
+            [$attributeDataToUpdate]
+        );
     }
 
     private function updateSyncTable($syncDataRecord) {

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -331,12 +331,7 @@ class Processor extends Main
             }
 
             if ($processedSyncDataRecordToUpdate) {
-                $syncDataSql = [];
-                $syncDataSql[] = $processedSyncDataRecordToUpdate;
-                $this->insertOnDuplicate(
-                    'yotpo_product_sync',
-                    $syncDataSql
-                );
+                $this->updateSyncTable($processedSyncDataRecordToUpdate);
                 $sqlData[] = $processedSyncDataRecordToUpdate;
             }
 
@@ -416,12 +411,7 @@ class Processor extends Main
                 ];
                 if (!$itemData['yotpo_id']) {
                     $tempDeleteQry['is_deleted_at_yotpo'] = 1;
-                    $sqlData = [];
-                    $sqlData[] = $tempDeleteQry;
-                    $this->insertOnDuplicate(
-                        'yotpo_product_sync',
-                        $sqlData
-                    );
+                    $this->updateSyncTable($tempDeleteQry);
                     continue;
                 }
 
@@ -440,12 +430,7 @@ class Processor extends Main
                     $returnResponse = $this->processResponse($params, $response, $tempDeleteQry, $itemData);
                 }
 
-                $sqlData = [];
-                $sqlData[] = $returnResponse['temp_sql'];
-                $this->insertOnDuplicate(
-                    'yotpo_product_sync',
-                    $sqlData
-                );
+                $this->updateSyncTable($returnResponse['temp_sql']);
             }
             $this->updateProductSyncLimit($dataCount);
         }
@@ -484,12 +469,7 @@ class Processor extends Main
                     $returnResponse = $this->processResponse($params, $response, $tempDeleteQry, $itemData);
                 }
 
-                $sqlData = [];
-                $sqlData[] = $returnResponse['temp_sql'];
-                $this->insertOnDuplicate(
-                    'yotpo_product_sync',
-                    $sqlData
-                );
+                $this->updateSyncTable($returnResponse['temp_sql']);
             }
             $this->updateProductSyncLimit($dataCount);
         }
@@ -758,5 +738,12 @@ class Processor extends Main
             'synced_to_yotpo' => $lastSyncTime,
             'response_code' => $responseCode
         ];
+    }
+
+    private function updateSyncTable($syncDataRecord) {
+        $this->insertOnDuplicate(
+            'yotpo_product_sync',
+            [$syncDataRecord]
+        );
     }
 }

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -233,7 +233,7 @@ class Processor extends Main
 
         $syncedToYotpoProductAttributeId = $this->catalogData->getAttributeId(CoreConfig::CATALOG_SYNC_ATTR_CODE);
         $items = $this->getSyncItems($collectionItems, $isVisibleVariantsSync);
-        $parentIds = $items['parent_ids'];
+        $parentItemsIds = $items['parent_ids'];
         $yotpoSyncTableItemsData = $items['yotpo_data'];
         $parentData = $items['parent_data'];
 
@@ -272,10 +272,10 @@ class Processor extends Main
                 continue;
             }
 
-            $apiParam = $this->getApiParams($itemId, $yotpoSyncTableItemsData, $parentIds, $parentData, $isVisibleVariantsSync);
+            $apiParam = $this->getApiParams($itemId, $yotpoSyncTableItemsData, $parentItemsIds, $parentData, $isVisibleVariantsSync);
 
             if (!$apiParam) {
-                $parentProductId = $parentIds[$itemId] ?? 0;
+                $parentProductId = $parentItemsIds[$itemId] ?? 0;
                 if ($parentProductId) {
                     continue;
                 }
@@ -349,7 +349,7 @@ class Processor extends Main
             //push to parentData array if parent product is
             // being the part of current collection
             if (!$isVisibleVariantsSync) {
-                $parentData = $this->pushParentData((int)$itemId, $tempSqlArray, $parentData, $parentIds);
+                $parentData = $this->pushParentData((int)$itemId, $tempSqlArray, $parentData, $parentItemsIds);
             }
 
             if ($tempSqlArray) {
@@ -376,7 +376,7 @@ class Processor extends Main
             $yotpoExistingProducts = $this->processExistData(
                 $externalIds,
                 $parentData,
-                $parentIds,
+                $parentItemsIds,
                 $isVisibleVariantsSync
             );
             if ($yotpoExistingProducts && $this->isSyncingAsMainEntity()) {

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -235,7 +235,7 @@ class Processor extends Main
         $items = $this->getSyncItems($collectionItems, $isVisibleVariantsSync);
         $parentItemsIds = $items['parent_ids'];
         $yotpoSyncTableItemsData = $items['yotpo_data'];
-        $parentData = $items['parent_data'];
+        $parentItemsData = $items['parent_data'];
 
         $lastSyncTime = '';
         $sqlData = $sqlDataIntTable = [];
@@ -272,7 +272,7 @@ class Processor extends Main
                 continue;
             }
 
-            $apiParam = $this->getApiParams($itemId, $yotpoSyncTableItemsData, $parentItemsIds, $parentData, $isVisibleVariantsSync);
+            $apiParam = $this->getApiParams($itemId, $yotpoSyncTableItemsData, $parentItemsIds, $parentItemsData, $isVisibleVariantsSync);
 
             if (!$apiParam) {
                 $parentProductId = $parentItemsIds[$itemId] ?? 0;
@@ -349,7 +349,7 @@ class Processor extends Main
             //push to parentData array if parent product is
             // being the part of current collection
             if (!$isVisibleVariantsSync) {
-                $parentData = $this->pushParentData((int)$itemId, $tempSqlArray, $parentData, $parentItemsIds);
+                $parentItemsData = $this->pushParentData((int)$itemId, $tempSqlArray, $parentItemsData, $parentItemsIds);
             }
 
             if ($tempSqlArray) {
@@ -375,7 +375,7 @@ class Processor extends Main
         if ($externalIds) {
             $yotpoExistingProducts = $this->processExistData(
                 $externalIds,
-                $parentData,
+                $parentItemsData,
                 $parentItemsIds,
                 $isVisibleVariantsSync
             );

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -516,13 +516,13 @@ class Processor extends Main
 
     /**
      * @param array <mixed> $items
-     * @param boolean $visibleVariants
+     * @param boolean $isVariantsDataIncluded
      * @return array <mixed>
      * @throws NoSuchEntityException
      */
-    protected function manageSyncItems($items, $visibleVariants = false): array
+    protected function manageSyncItems($items, $isVariantsDataIncluded = false): array
     {
-        return $this->catalogData->manageSyncItems($items, $visibleVariants);
+        return $this->catalogData->manageSyncItems($items, $isVariantsDataIncluded);
     }
 
     /**

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -244,15 +244,15 @@ class Processor extends Main
         $visibleVariantsDataValues = array_values($visibleVariantsData);
 
         $itemsToBeSyncedToYotpo = $items['sync_data'];
-        foreach ($itemsToBeSyncedToYotpo as $itemId => $itemData) {
+        foreach ($itemsToBeSyncedToYotpo as $itemEntityId => $itemData) {
             $rowId = $itemData['row_id'];
             unset($itemData['row_id']);
 
             if ($yotpoSyncTableItemsData
-                && array_key_exists($itemId, $yotpoSyncTableItemsData)
+                && array_key_exists($itemEntityId, $yotpoSyncTableItemsData)
                 && !$this->coreConfig->canResync(
-                    $yotpoSyncTableItemsData[$itemId]['response_code'],
-                    $yotpoSyncTableItemsData[$itemId],
+                    $yotpoSyncTableItemsData[$itemEntityId]['response_code'],
+                    $yotpoSyncTableItemsData[$itemEntityId],
                     $this->isCommandLineSync
                 )
             ) {
@@ -273,10 +273,10 @@ class Processor extends Main
                 continue;
             }
 
-            $apiParam = $this->getApiParams($itemId, $yotpoSyncTableItemsData, $parentItemsIds, $parentItemsData, $isVisibleVariantsSync);
+            $apiParam = $this->getApiParams($itemEntityId, $yotpoSyncTableItemsData, $parentItemsIds, $parentItemsData, $isVisibleVariantsSync);
 
             if (!$apiParam) {
-                $parentProductId = $parentItemsIds[$itemId] ?? 0;
+                $parentProductId = $parentItemsIds[$itemEntityId] ?? 0;
                 if ($parentProductId) {
                     continue;
                 }
@@ -295,7 +295,7 @@ class Processor extends Main
             $lastSyncTime = $this->getCurrentTime();
             $yotpoIdKey = $isVisibleVariantsSync ? 'visible_variant_yotpo_id' : 'yotpo_id';
             $tempSqlArray = [
-                'product_id' => $itemId,
+                'product_id' => $itemEntityId,
                 $yotpoIdKey => $apiParam['yotpo_id'] ?: 0,
                 'store_id' => $storeId,
                 'synced_to_yotpo' => $lastSyncTime,
@@ -334,8 +334,8 @@ class Processor extends Main
             $tempSqlArray = $returnResponse['temp_sql'];
             $externalIds = $returnResponse['external_id'];
 
-            if (isset($this->retryItems[$storeId][$itemId])) {
-                unset($this->retryItems[$storeId][$itemId]);
+            if (isset($this->retryItems[$storeId][$itemEntityId])) {
+                unset($this->retryItems[$storeId][$itemEntityId]);
             }
 
             if (count($returnResponse['four_not_four_data'])) {
@@ -350,7 +350,7 @@ class Processor extends Main
             //push to parentData array if parent product is
             // being the part of current collection
             if (!$isVisibleVariantsSync) {
-                $parentItemsData = $this->pushParentData((int)$itemId, $tempSqlArray, $parentItemsData, $parentItemsIds);
+                $parentItemsData = $this->pushParentData((int)$itemEntityId, $tempSqlArray, $parentItemsData, $parentItemsIds);
             }
 
             if ($tempSqlArray) {
@@ -365,7 +365,7 @@ class Processor extends Main
 
             if ($this->isCommandLineSync && !$this->isImmediateRetry) {
                 // phpcs:ignore
-                echo 'Catalog process completed for productid - ' . $itemId . PHP_EOL;
+                echo 'Catalog process completed for productid - ' . $itemEntityId . PHP_EOL;
             }
         }
         $dataToSent = [];

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -252,18 +252,11 @@ class Processor extends Main
                 && array_key_exists($itemEntityId, $yotpoSyncTableItemsData)
                 && !$this->shouldItemBeResynced($yotpoSyncTableItemsData[$itemEntityId])
             ) {
-                $tempSqlDataIntTable = [
-                    'attribute_id' => $syncedToYotpoProductAttributeId,
-                    'store_id' => $storeId,
-                    'value' => 1,
-                    $this->entityIdFieldValue => $itemRowId
-                ];
-                $sqlDataIntTable = [];
-                $sqlDataIntTable[] = $tempSqlDataIntTable;
+                $attributeDataToUpdate = $this->prepareAttributeDataToUpdate($storeId, $itemRowId, $syncedToYotpoProductAttributeId);
                 if ($this->isSyncingAsMainEntity()) {
                     $this->insertOnDuplicate(
                         'catalog_product_entity_int',
-                        $sqlDataIntTable
+                        [$attributeDataToUpdate]
                     );
                 }
                 continue;
@@ -302,18 +295,11 @@ class Processor extends Main
                 $tempSqlArray['yotpo_id_parent'] = $apiParam['yotpo_id_parent'] ?: 0;
             }
             if ($this->coreConfig->canUpdateCustomAttributeForProducts($tempSqlArray['response_code'])) {
-                $tempSqlDataIntTable = [
-                    'attribute_id' => $syncedToYotpoProductAttributeId,
-                    'store_id' => $storeId,
-                    'value' => 1,
-                    $this->entityIdFieldValue => $itemRowId
-                ];
-                $sqlDataIntTable = [];
-                $sqlDataIntTable[] = $tempSqlDataIntTable;
+                $attributeDataToUpdate = $this->prepareAttributeDataToUpdate($storeId, $itemRowId, $syncedToYotpoProductAttributeId);
                 if ($this->isSyncingAsMainEntity()) {
                     $this->insertOnDuplicate(
                         'catalog_product_entity_int',
-                        $sqlDataIntTable
+                        [$attributeDataToUpdate]
                     );
                 }
             }
@@ -758,5 +744,15 @@ class Processor extends Main
     private function shouldItemBeResynced($yotpoSyncTableItemData)
     {
         return $this->coreConfig->canResync($yotpoSyncTableItemData['response_code'], $yotpoSyncTableItemData, $this->isCommandLineSync);
+    }
+
+    private function prepareAttributeDataToUpdate($storeId, $itemRowId, $syncedToYotpoProductAttributeId)
+    {
+        return [
+            'attribute_id' => $syncedToYotpoProductAttributeId,
+            'store_id' => $storeId,
+            'value' => 1,
+            $this->entityIdFieldValue => $itemRowId
+        ];
     }
 }

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -234,7 +234,7 @@ class Processor extends Main
         $syncedToYotpoProductAttributeId = $this->catalogData->getAttributeId(CoreConfig::CATALOG_SYNC_ATTR_CODE);
         $items = $this->getSyncItems($collectionItems, $isVisibleVariantsSync);
         $parentIds = $items['parent_ids'];
-        $yotpoData = $items['yotpo_data'];
+        $yotpoSyncTableItemsData = $items['yotpo_data'];
         $parentData = $items['parent_data'];
 
         $lastSyncTime = '';
@@ -247,11 +247,11 @@ class Processor extends Main
             $rowId = $itemData['row_id'];
             unset($itemData['row_id']);
 
-            if ($yotpoData
-                && array_key_exists($itemId, $yotpoData)
+            if ($yotpoSyncTableItemsData
+                && array_key_exists($itemId, $yotpoSyncTableItemsData)
                 && !$this->coreConfig->canResync(
-                    $yotpoData[$itemId]['response_code'],
-                    $yotpoData[$itemId],
+                    $yotpoSyncTableItemsData[$itemId]['response_code'],
+                    $yotpoSyncTableItemsData[$itemId],
                     $this->isCommandLineSync
                 )
             ) {
@@ -272,7 +272,7 @@ class Processor extends Main
                 continue;
             }
 
-            $apiParam = $this->getApiParams($itemId, $yotpoData, $parentIds, $parentData, $isVisibleVariantsSync);
+            $apiParam = $this->getApiParams($itemId, $yotpoSyncTableItemsData, $parentIds, $parentData, $isVisibleVariantsSync);
 
             if (!$apiParam) {
                 $parentProductId = $parentIds[$itemId] ?? 0;

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -236,8 +236,8 @@ class Processor extends Main
         $parentItemsIds = $items['parent_ids'];
         $yotpoSyncTableItemsData = $items['yotpo_data'];
         $parentItemsData = $items['parent_data'];
-        
-        $sqlData = $sqlDataIntTable = [];
+
+        $sqlData = [];
         $externalIds = [];
         $visibleVariantsData = $isVisibleVariantsSync ? [] : $items['visible_variants'];
         $visibleVariantsDataValues = array_values($visibleVariantsData);

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -244,9 +244,9 @@ class Processor extends Main
         $visibleVariantsDataValues = array_values($visibleVariantsData);
 
         $itemsToBeSyncedToYotpo = $items['sync_data'];
-        foreach ($itemsToBeSyncedToYotpo as $itemEntityId => $itemData) {
-            $rowId = $itemData['row_id'];
-            unset($itemData['row_id']);
+        foreach ($itemsToBeSyncedToYotpo as $itemEntityId => $yotpoFormatItemData) {
+            $rowId = $yotpoFormatItemData['row_id'];
+            unset($yotpoFormatItemData['row_id']);
 
             if ($yotpoSyncTableItemsData
                 && array_key_exists($itemEntityId, $yotpoSyncTableItemsData)
@@ -290,7 +290,7 @@ class Processor extends Main
                     $this->coreConfig->getStoreName($storeId)
                 )
             );
-            $response = $this->processRequest($apiParam, $itemData);
+            $response = $this->processRequest($apiParam, $yotpoFormatItemData);
 
             $lastSyncTime = $this->getCurrentTime();
             $yotpoIdKey = $isVisibleVariantsSync ? 'visible_variant_yotpo_id' : 'yotpo_id';
@@ -326,7 +326,7 @@ class Processor extends Main
                 $apiParam,
                 $response,
                 $tempSqlArray,
-                $itemData,
+                $yotpoFormatItemData,
                 $externalIds,
                 $isVisibleVariantsSync
             );

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -23,6 +23,8 @@ use Yotpo\Core\Api\ProductSyncRepositoryInterface;
 class Processor extends Main
 {
 
+    const CREATED_STATUS_CODE = '201';
+
     /**
      * @var CatalogData
      */
@@ -258,6 +260,23 @@ class Processor extends Main
                     $this->updateProductSyncAttribute($attributeDataToUpdate);
                 }
                 continue;
+            }
+
+            if (!$isVisibleVariantsSync && isset($parentItemsIds[$itemEntityId])) {
+                $parentItemId = $parentItemsIds[$itemEntityId];
+
+                if (!$this->isProductParentYotpoIdFound($parentItemsData, $parentItemId)) {
+                    $this->yotpoCatalogLogger->info('Start syncing variant without parent in Yotpo', ['external_product_id', $parentItemId]);
+                    $parentProductYotpoId = $this->ensureVariantParentExistenceInYotpo($parentItemId);
+
+                    if ($parentProductYotpoId) {
+                        $parentItemsData[$parentItemId] = [
+                            'product_id' => $parentItemId,
+                            'yotpo_id' => $parentProductYotpoId
+                        ];
+                        $this->yotpoCatalogLogger->info('Finished syncing variant without parent in Yotpo', ['external_product_id', $parentItemId, 'product_id', $parentProductYotpoId]);
+                    }
+                }
             }
 
             $apiRequestParams = $this->getApiParams($itemEntityId, $yotpoSyncTableItemsData, $parentItemsIds, $parentItemsData, $isVisibleVariantsSync);
@@ -772,5 +791,34 @@ class Processor extends Main
             'yotpo_product_sync',
             [$syncDataRecord]
         );
+    }
+
+    /**
+     * @param string $parentId
+     * @return string
+     */
+    private function ensureVariantParentExistenceInYotpo($parentId)
+    {
+        $parentProductsData = $this->getCollectionForSync([$parentId])->getItems();
+        if (!count($parentProductsData)) {
+            return null;
+        }
+
+        $apiUrl = $this->coreConfig->getEndpoint('products');
+        $method = $this->coreConfig->getProductSyncMethod('createProduct');
+        $apiParam = [
+            'url' => $apiUrl,
+            'method' => $method,
+        ];
+
+        $productData = $this->catalogData->attributeMapping(reset($parentProductsData));
+        $response = $this->processRequest($apiParam, $productData);
+        if ($response->getData('status') != $this::CREATED_STATUS_CODE) {
+            $this->yotpoCatalogLogger->info('Failed syncing missing variant parent product to Yotpo',
+                ['status_code', $response->getData('status'),
+                 'reason', $response->getData('reason')]);
+        }
+
+        return $this->getYotpoIdFromResponse($response, $method);
     }
 }

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -237,7 +237,7 @@ class Processor extends Main
         $yotpoSyncTableItemsData = $items['yotpo_data'];
         $parentItemsData = $items['parent_data'];
 
-        $sqlData = [];
+        $syncTableRecordsUpdated = [];
         $externalIds = [];
         $visibleVariantsData = $isVisibleVariantsSync ? [] : $items['visible_variants'];
         $visibleVariantsDataValues = array_values($visibleVariantsData);
@@ -325,7 +325,7 @@ class Processor extends Main
 
             if ($processedSyncDataRecordToUpdate) {
                 $this->updateSyncTable($processedSyncDataRecordToUpdate);
-                $sqlData[] = $processedSyncDataRecordToUpdate;
+                $syncTableRecordsUpdated[] = $processedSyncDataRecordToUpdate;
             }
 
             if ($this->isCommandLineSync && !$this->isImmediateRetry) {
@@ -334,8 +334,8 @@ class Processor extends Main
             }
         }
         $dataToSent = [];
-        if (count($sqlData)) {
-            $dataToSent = array_merge($dataToSent, $this->catalogData->filterDataForCatSync($sqlData));
+        if (count($syncTableRecordsUpdated)) {
+            $dataToSent = array_merge($dataToSent, $this->catalogData->filterDataForCatSync($syncTableRecordsUpdated));
         }
 
         if ($externalIds) {

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -142,7 +142,7 @@ class Processor extends Main
                                 $this->coreConfig->getStoreName($storeId) . PHP_EOL;
                         }
                     }
-                    if ($this->normalSync && !$this->coreConfig->isCatalogSyncActive()) {
+                    if ($this->isSyncingAsMainEntity() && !$this->coreConfig->isCatalogSyncActive()) {
                         $disabled = true;
                         $this->yotpoCatalogLogger->info(
                             __(
@@ -169,7 +169,7 @@ class Processor extends Main
                             $this->coreConfig->getStoreName($storeId)
                         )
                     );
-                    if ($this->normalSync) {
+                    if ($this->isSyncingAsMainEntity()) {
                         $this->processDeleteData();
                         $this->processUnAssignData();
                     }
@@ -198,7 +198,7 @@ class Processor extends Main
                 $this->stopEnvironmentEmulation();
             }
             $this->stopEnvironmentEmulation();
-            if (!$this->normalSync && count($unSyncedStoreIds) > 0) {
+            if (!$this->isSyncingAsMainEntity() && count($unSyncedStoreIds) > 0) {
                 return false;
             } else {
                 return true;
@@ -253,7 +253,7 @@ class Processor extends Main
                     ];
                     $sqlDataIntTable = [];
                     $sqlDataIntTable[] = $tempSqlDataIntTable;
-                    if ($this->normalSync) {
+                    if ($this->isSyncingAsMainEntity()) {
                         $this->insertOnDuplicate(
                             'catalog_product_entity_int',
                             $sqlDataIntTable
@@ -303,7 +303,7 @@ class Processor extends Main
                     ];
                     $sqlDataIntTable = [];
                     $sqlDataIntTable[] = $tempSqlDataIntTable;
-                    if ($this->normalSync) {
+                    if ($this->isSyncingAsMainEntity()) {
                         $this->insertOnDuplicate(
                             'catalog_product_entity_int',
                             $sqlDataIntTable
@@ -367,7 +367,7 @@ class Processor extends Main
                     $parentIds,
                     $isVisibleVariantsSync
                 );
-                if ($yotpoExistingProducts && $this->normalSync) {
+                if ($yotpoExistingProducts && $this->isSyncingAsMainEntity()) {
                     $dataToSent = array_merge(
                         $dataToSent,
                         $this->catalogData->filterDataForCatSync($yotpoExistingProducts)
@@ -375,7 +375,7 @@ class Processor extends Main
                 }
             }
 
-            if ($this->normalSync) {
+            if ($this->isSyncingAsMainEntity()) {
                 $this->coreConfig->saveConfig('catalog_last_sync_time', $lastSyncTime);
                 $dataForCategorySync = [];
                 if ($dataToSent && !$isVisibleVariantsSync) {

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -231,7 +231,7 @@ class Processor extends Main
             return;
         }
 
-        $attributeId = $this->catalogData->getAttributeId(CoreConfig::CATALOG_SYNC_ATTR_CODE);
+        $syncedToYotpoProductAttributeId = $this->catalogData->getAttributeId(CoreConfig::CATALOG_SYNC_ATTR_CODE);
         $items = $this->getSyncItems($collectionItems, $isVisibleVariantsSync);
         $parentIds = $items['parent_ids'];
         $yotpoData = $items['yotpo_data'];
@@ -256,7 +256,7 @@ class Processor extends Main
                 )
             ) {
                 $tempSqlDataIntTable = [
-                    'attribute_id' => $attributeId,
+                    'attribute_id' => $syncedToYotpoProductAttributeId,
                     'store_id' => $storeId,
                     'value' => 1,
                     $this->entityIdFieldValue => $rowId
@@ -306,7 +306,7 @@ class Processor extends Main
             }
             if ($this->coreConfig->canUpdateCustomAttributeForProducts($tempSqlArray['response_code'])) {
                 $tempSqlDataIntTable = [
-                    'attribute_id' => $attributeId,
+                    'attribute_id' => $syncedToYotpoProductAttributeId,
                     'store_id' => $storeId,
                     'value' => 1,
                     $this->entityIdFieldValue => $rowId

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -281,7 +281,7 @@ class Processor extends Main
                 )
             );
 
-            $response = $this->processRequest($apiRequestParams, $magentoItemData);
+            $response = $this->processRequest($apiRequestParams, $yotpoFormatItemData);
 
             $lastSyncTime = $this->getCurrentTime();
             $yotpoIdKey = $isVisibleVariantsSync ? 'visible_variant_yotpo_id' : 'yotpo_id';

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -222,7 +222,7 @@ class Processor extends Main
     {
         if (count($collectionItems)) {
             $attributeId = $this->catalogData->getAttributeId(CoreConfig::CATALOG_SYNC_ATTR_CODE);
-            $items = $this->manageSyncItems($collectionItems, $isVisibleVariantsSync);
+            $items = $this->getSyncItems($collectionItems, $isVisibleVariantsSync);
             $parentIds = $items['parent_ids'];
             $yotpoData = $items['yotpo_data'];
             $parentData = $items['parent_data'];
@@ -520,9 +520,9 @@ class Processor extends Main
      * @return array <mixed>
      * @throws NoSuchEntityException
      */
-    protected function manageSyncItems($items, $isVariantsDataIncluded = false): array
+    protected function getSyncItems($items, $isVariantsDataIncluded = false): array
     {
-        return $this->catalogData->manageSyncItems($items, $isVariantsDataIncluded);
+        return $this->catalogData->getSyncItems($items, $isVariantsDataIncluded);
     }
 
     /**

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -520,7 +520,7 @@ class Processor extends Main
      * @return array <mixed>
      * @throws NoSuchEntityException
      */
-    protected function getSyncItems($items, $isVariantsDataIncluded = false): array
+    protected function getSyncItems($items, $isVariantsDataIncluded): array
     {
         return $this->catalogData->getSyncItems($items, $isVariantsDataIncluded);
     }

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -243,7 +243,8 @@ class Processor extends Main
         $visibleVariantsData = $isVisibleVariantsSync ? [] : $items['visible_variants'];
         $visibleVariantsDataValues = array_values($visibleVariantsData);
 
-        foreach ($items['sync_data'] as $itemId => $itemData) {
+        $itemsToBeSyncedToYotpo = $items['sync_data'];
+        foreach ($itemsToBeSyncedToYotpo as $itemId => $itemData) {
             $rowId = $itemData['row_id'];
             unset($itemData['row_id']);
 

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -308,7 +308,7 @@ class Processor extends Main
                 $isVisibleVariantsSync
             );
 
-            $syncDataRecordToUpdate = $returnResponse['temp_sql'];
+            $processedSyncDataRecordToUpdate = $returnResponse['temp_sql'];
             $externalIds = $returnResponse['external_id'];
 
             if (isset($this->retryItems[$storeId][$itemEntityId])) {
@@ -327,17 +327,17 @@ class Processor extends Main
             //push to parentData array if parent product is
             // being the part of current collection
             if (!$isVisibleVariantsSync) {
-                $parentItemsData = $this->pushParentData((int)$itemEntityId, $syncDataRecordToUpdate, $parentItemsData, $parentItemsIds);
+                $parentItemsData = $this->pushParentData((int)$itemEntityId, $processedSyncDataRecordToUpdate, $parentItemsData, $parentItemsIds);
             }
 
-            if ($syncDataRecordToUpdate) {
+            if ($processedSyncDataRecordToUpdate) {
                 $syncDataSql = [];
-                $syncDataSql[] = $syncDataRecordToUpdate;
+                $syncDataSql[] = $processedSyncDataRecordToUpdate;
                 $this->insertOnDuplicate(
                     'yotpo_product_sync',
                     $syncDataSql
                 );
-                $sqlData[] = $syncDataRecordToUpdate;
+                $sqlData[] = $processedSyncDataRecordToUpdate;
             }
 
             if ($this->isCommandLineSync && !$this->isImmediateRetry) {

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -220,192 +220,7 @@ class Processor extends Main
      */
     public function syncItems($collectionItems, $storeId, $isVisibleVariantsSync = false)
     {
-        if (count($collectionItems)) {
-            $attributeId = $this->catalogData->getAttributeId(CoreConfig::CATALOG_SYNC_ATTR_CODE);
-            $items = $this->getSyncItems($collectionItems, $isVisibleVariantsSync);
-            $parentIds = $items['parent_ids'];
-            $yotpoData = $items['yotpo_data'];
-            $parentData = $items['parent_data'];
-
-            $lastSyncTime = '';
-            $sqlData = $sqlDataIntTable = [];
-            $externalIds = [];
-            $visibleVariantsData = $isVisibleVariantsSync ? [] : $items['visible_variants'];
-            $visibleVariantsDataValues = array_values($visibleVariantsData);
-
-            foreach ($items['sync_data'] as $itemId => $itemData) {
-                $rowId = $itemData['row_id'];
-                unset($itemData['row_id']);
-
-                if ($yotpoData
-                    && array_key_exists($itemId, $yotpoData)
-                    && !$this->coreConfig->canResync(
-                        $yotpoData[$itemId]['response_code'],
-                        $yotpoData[$itemId],
-                        $this->isCommandLineSync
-                    )
-                ) {
-                    $tempSqlDataIntTable = [
-                        'attribute_id' => $attributeId,
-                        'store_id' => $storeId,
-                        'value' => 1,
-                        $this->entityIdFieldValue => $rowId
-                    ];
-                    $sqlDataIntTable = [];
-                    $sqlDataIntTable[] = $tempSqlDataIntTable;
-                    if ($this->isSyncingAsMainEntity()) {
-                        $this->insertOnDuplicate(
-                            'catalog_product_entity_int',
-                            $sqlDataIntTable
-                        );
-                    }
-                    continue;
-                }
-
-                $apiParam = $this->getApiParams($itemId, $yotpoData, $parentIds, $parentData, $isVisibleVariantsSync);
-
-                if (!$apiParam) {
-                    $parentProductId = $parentIds[$itemId] ?? 0;
-                    if ($parentProductId) {
-                        continue;
-                    }
-                }
-
-                $this->yotpoCatalogLogger->info(
-                    __(
-                        'Data ready to sync - Method: %1 - Magento Store ID: %2, Name: %3',
-                        $apiParam['method'],
-                        $storeId,
-                        $this->coreConfig->getStoreName($storeId)
-                    )
-                );
-                $response = $this->processRequest($apiParam, $itemData);
-
-                $lastSyncTime = $this->getCurrentTime();
-                $yotpoIdKey = $isVisibleVariantsSync ? 'visible_variant_yotpo_id' : 'yotpo_id';
-                $tempSqlArray = [
-                    'product_id' => $itemId,
-                    $yotpoIdKey => $apiParam['yotpo_id'] ?: 0,
-                    'store_id' => $storeId,
-                    'synced_to_yotpo' => $lastSyncTime,
-                    'response_code' => $response->getData('status'),
-                    'sync_status' => 1
-                ];
-                if (!$isVisibleVariantsSync) {
-                    $tempSqlArray['yotpo_id_parent'] = $apiParam['yotpo_id_parent'] ?: 0;
-                }
-                if ($this->coreConfig->canUpdateCustomAttributeForProducts($tempSqlArray['response_code'])) {
-                    $tempSqlDataIntTable = [
-                        'attribute_id' => $attributeId,
-                        'store_id' => $storeId,
-                        'value' => 1,
-                        $this->entityIdFieldValue => $rowId
-                    ];
-                    $sqlDataIntTable = [];
-                    $sqlDataIntTable[] = $tempSqlDataIntTable;
-                    if ($this->isSyncingAsMainEntity()) {
-                        $this->insertOnDuplicate(
-                            'catalog_product_entity_int',
-                            $sqlDataIntTable
-                        );
-                    }
-                }
-
-                $returnResponse = $this->processResponse(
-                    $apiParam,
-                    $response,
-                    $tempSqlArray,
-                    $itemData,
-                    $externalIds,
-                    $isVisibleVariantsSync
-                );
-
-                $tempSqlArray = $returnResponse['temp_sql'];
-                $externalIds = $returnResponse['external_id'];
-
-                if (isset($this->retryItems[$storeId][$itemId])) {
-                    unset($this->retryItems[$storeId][$itemId]);
-                }
-
-                if (count($returnResponse['four_not_four_data'])) {
-                    foreach ($returnResponse['four_not_four_data'] as $retryId) {
-                        if ($this->isImmediateRetry($response, $this->entity, $isVisibleVariantsSync.$retryId, $storeId)) {
-                            $this->setImmediateRetryAlreadyDone($this->entity, $isVisibleVariantsSync.$retryId, $storeId);
-                            $this->retryItems[$storeId][$retryId] = $retryId;
-                        }
-                    }
-                }
-
-                //push to parentData array if parent product is
-                // being the part of current collection
-                if (!$isVisibleVariantsSync) {
-                    $parentData = $this->pushParentData((int)$itemId, $tempSqlArray, $parentData, $parentIds);
-                }
-                if ($tempSqlArray) {
-                    $syncDataSql = [];
-                    $syncDataSql[] = $tempSqlArray;
-                    $this->insertOnDuplicate(
-                        'yotpo_product_sync',
-                        $syncDataSql
-                    );
-                    $sqlData[] = $tempSqlArray;
-                }
-                if ($this->isCommandLineSync && !$this->isImmediateRetry) {
-                    // phpcs:ignore
-                    echo 'Catalog process completed for productid - ' . $itemId . PHP_EOL;
-                }
-            }
-            $dataToSent = [];
-            if (count($sqlData)) {
-                $dataToSent = array_merge($dataToSent, $this->catalogData->filterDataForCatSync($sqlData));
-            }
-
-            if ($externalIds) {
-                $yotpoExistingProducts = $this->processExistData(
-                    $externalIds,
-                    $parentData,
-                    $parentIds,
-                    $isVisibleVariantsSync
-                );
-                if ($yotpoExistingProducts && $this->isSyncingAsMainEntity()) {
-                    $dataToSent = array_merge(
-                        $dataToSent,
-                        $this->catalogData->filterDataForCatSync($yotpoExistingProducts)
-                    );
-                }
-            }
-
-            if ($this->isSyncingAsMainEntity()) {
-                $this->coreConfig->saveConfig('catalog_last_sync_time', $lastSyncTime);
-                $dataForCategorySync = [];
-                if ($dataToSent && !$isVisibleVariantsSync) {
-                    $dataForCategorySync = $this->getProductsForCategorySync(
-                        $dataToSent,
-                        $collectionItems,
-                        $dataForCategorySync
-                    );
-                }
-                if (count($dataForCategorySync) > 0) {
-                    $this->categorySyncProcessor->process($dataForCategorySync);
-                }
-            }
-
-            $reSyncYotpoKey = $isVisibleVariantsSync ? 'visible_variant_yotpo_id' : 'yotpo_id';
-            if (isset($this->retryItems[$storeId]) && count($this->retryItems[$storeId]) > 0) {
-                $this->update(
-                    'yotpo_product_sync',
-                    [$reSyncYotpoKey => 0, 'response_code' => coreConfig::CUSTOM_RESPONSE_DATA],
-                    ['product_id' . ' IN (?)' => $this->retryItems[$storeId], 'store_id = ?' => $storeId]
-                );
-                $collection = $this->getCollectionForSync($this->retryItems[$storeId]);
-                $this->isImmediateRetry = true;
-                $this->syncItems($collection->getItems(), $storeId, $isVisibleVariantsSync);
-            }
-
-            if ($visibleVariantsDataValues && !$isVisibleVariantsSync) {
-                $this->syncItems($visibleVariantsDataValues, $storeId, true);
-            }
-        } else {
+        if (!count($collectionItems)) {
             $this->yotpoCatalogLogger->info(
                 __(
                     'Product Sync complete : No Data, Magento Store ID: %1, Name: %2',
@@ -413,6 +228,194 @@ class Processor extends Main
                     $this->coreConfig->getStoreName($storeId)
                 )
             );
+            return;
+        }
+
+        $attributeId = $this->catalogData->getAttributeId(CoreConfig::CATALOG_SYNC_ATTR_CODE);
+        $items = $this->getSyncItems($collectionItems, $isVisibleVariantsSync);
+        $parentIds = $items['parent_ids'];
+        $yotpoData = $items['yotpo_data'];
+        $parentData = $items['parent_data'];
+
+        $lastSyncTime = '';
+        $sqlData = $sqlDataIntTable = [];
+        $externalIds = [];
+        $visibleVariantsData = $isVisibleVariantsSync ? [] : $items['visible_variants'];
+        $visibleVariantsDataValues = array_values($visibleVariantsData);
+
+        foreach ($items['sync_data'] as $itemId => $itemData) {
+            $rowId = $itemData['row_id'];
+            unset($itemData['row_id']);
+
+            if ($yotpoData
+                && array_key_exists($itemId, $yotpoData)
+                && !$this->coreConfig->canResync(
+                    $yotpoData[$itemId]['response_code'],
+                    $yotpoData[$itemId],
+                    $this->isCommandLineSync
+                )
+            ) {
+                $tempSqlDataIntTable = [
+                    'attribute_id' => $attributeId,
+                    'store_id' => $storeId,
+                    'value' => 1,
+                    $this->entityIdFieldValue => $rowId
+                ];
+                $sqlDataIntTable = [];
+                $sqlDataIntTable[] = $tempSqlDataIntTable;
+                if ($this->isSyncingAsMainEntity()) {
+                    $this->insertOnDuplicate(
+                        'catalog_product_entity_int',
+                        $sqlDataIntTable
+                    );
+                }
+                continue;
+            }
+
+            $apiParam = $this->getApiParams($itemId, $yotpoData, $parentIds, $parentData, $isVisibleVariantsSync);
+
+            if (!$apiParam) {
+                $parentProductId = $parentIds[$itemId] ?? 0;
+                if ($parentProductId) {
+                    continue;
+                }
+            }
+
+            $this->yotpoCatalogLogger->info(
+                __(
+                    'Data ready to sync - Method: %1 - Magento Store ID: %2, Name: %3',
+                    $apiParam['method'],
+                    $storeId,
+                    $this->coreConfig->getStoreName($storeId)
+                )
+            );
+            $response = $this->processRequest($apiParam, $itemData);
+
+            $lastSyncTime = $this->getCurrentTime();
+            $yotpoIdKey = $isVisibleVariantsSync ? 'visible_variant_yotpo_id' : 'yotpo_id';
+            $tempSqlArray = [
+                'product_id' => $itemId,
+                $yotpoIdKey => $apiParam['yotpo_id'] ?: 0,
+                'store_id' => $storeId,
+                'synced_to_yotpo' => $lastSyncTime,
+                'response_code' => $response->getData('status'),
+                'sync_status' => 1
+            ];
+            if (!$isVisibleVariantsSync) {
+                $tempSqlArray['yotpo_id_parent'] = $apiParam['yotpo_id_parent'] ?: 0;
+            }
+            if ($this->coreConfig->canUpdateCustomAttributeForProducts($tempSqlArray['response_code'])) {
+                $tempSqlDataIntTable = [
+                    'attribute_id' => $attributeId,
+                    'store_id' => $storeId,
+                    'value' => 1,
+                    $this->entityIdFieldValue => $rowId
+                ];
+                $sqlDataIntTable = [];
+                $sqlDataIntTable[] = $tempSqlDataIntTable;
+                if ($this->isSyncingAsMainEntity()) {
+                    $this->insertOnDuplicate(
+                        'catalog_product_entity_int',
+                        $sqlDataIntTable
+                    );
+                }
+            }
+
+            $returnResponse = $this->processResponse(
+                $apiParam,
+                $response,
+                $tempSqlArray,
+                $itemData,
+                $externalIds,
+                $isVisibleVariantsSync
+            );
+
+            $tempSqlArray = $returnResponse['temp_sql'];
+            $externalIds = $returnResponse['external_id'];
+
+            if (isset($this->retryItems[$storeId][$itemId])) {
+                unset($this->retryItems[$storeId][$itemId]);
+            }
+
+            if (count($returnResponse['four_not_four_data'])) {
+                foreach ($returnResponse['four_not_four_data'] as $retryId) {
+                    if ($this->isImmediateRetry($response, $this->entity, $isVisibleVariantsSync.$retryId, $storeId)) {
+                        $this->setImmediateRetryAlreadyDone($this->entity, $isVisibleVariantsSync.$retryId, $storeId);
+                        $this->retryItems[$storeId][$retryId] = $retryId;
+                    }
+                }
+            }
+
+            //push to parentData array if parent product is
+            // being the part of current collection
+            if (!$isVisibleVariantsSync) {
+                $parentData = $this->pushParentData((int)$itemId, $tempSqlArray, $parentData, $parentIds);
+            }
+
+            if ($tempSqlArray) {
+                $syncDataSql = [];
+                $syncDataSql[] = $tempSqlArray;
+                $this->insertOnDuplicate(
+                    'yotpo_product_sync',
+                    $syncDataSql
+                );
+                $sqlData[] = $tempSqlArray;
+            }
+
+            if ($this->isCommandLineSync && !$this->isImmediateRetry) {
+                // phpcs:ignore
+                echo 'Catalog process completed for productid - ' . $itemId . PHP_EOL;
+            }
+        }
+        $dataToSent = [];
+        if (count($sqlData)) {
+            $dataToSent = array_merge($dataToSent, $this->catalogData->filterDataForCatSync($sqlData));
+        }
+
+        if ($externalIds) {
+            $yotpoExistingProducts = $this->processExistData(
+                $externalIds,
+                $parentData,
+                $parentIds,
+                $isVisibleVariantsSync
+            );
+            if ($yotpoExistingProducts && $this->isSyncingAsMainEntity()) {
+                $dataToSent = array_merge(
+                    $dataToSent,
+                    $this->catalogData->filterDataForCatSync($yotpoExistingProducts)
+                );
+            }
+        }
+
+        if ($this->isSyncingAsMainEntity()) {
+            $this->coreConfig->saveConfig('catalog_last_sync_time', $lastSyncTime);
+            $dataForCategorySync = [];
+            if ($dataToSent && !$isVisibleVariantsSync) {
+                $dataForCategorySync = $this->getProductsForCategorySync(
+                    $dataToSent,
+                    $collectionItems,
+                    $dataForCategorySync
+                );
+            }
+            if (count($dataForCategorySync) > 0) {
+                $this->categorySyncProcessor->process($dataForCategorySync);
+            }
+        }
+
+        $reSyncYotpoKey = $isVisibleVariantsSync ? 'visible_variant_yotpo_id' : 'yotpo_id';
+        if (isset($this->retryItems[$storeId]) && count($this->retryItems[$storeId]) > 0) {
+            $this->update(
+                'yotpo_product_sync',
+                [$reSyncYotpoKey => 0, 'response_code' => coreConfig::CUSTOM_RESPONSE_DATA],
+                ['product_id' . ' IN (?)' => $this->retryItems[$storeId], 'store_id = ?' => $storeId]
+            );
+            $collection = $this->getCollectionForSync($this->retryItems[$storeId]);
+            $this->isImmediateRetry = true;
+            $this->syncItems($collection->getItems(), $storeId, $isVisibleVariantsSync);
+        }
+
+        if ($visibleVariantsDataValues && !$isVisibleVariantsSync) {
+            $this->syncItems($visibleVariantsDataValues, $storeId, true);
         }
     }
 

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -263,9 +263,9 @@ class Processor extends Main
                 continue;
             }
 
-            $apiParam = $this->getApiParams($itemEntityId, $yotpoSyncTableItemsData, $parentItemsIds, $parentItemsData, $isVisibleVariantsSync);
+            $apiRequestParams = $this->getApiParams($itemEntityId, $yotpoSyncTableItemsData, $parentItemsIds, $parentItemsData, $isVisibleVariantsSync);
 
-            if (!$apiParam) {
+            if (!$apiRequestParams) {
                 $parentProductId = $parentItemsIds[$itemEntityId] ?? 0;
                 if ($parentProductId) {
                     continue;
@@ -275,25 +275,26 @@ class Processor extends Main
             $this->yotpoCatalogLogger->info(
                 __(
                     'Data ready to sync - Method: %1 - Magento Store ID: %2, Name: %3',
-                    $apiParam['method'],
+                    $apiRequestParams['method'],
                     $storeId,
                     $this->coreConfig->getStoreName($storeId)
                 )
             );
-            $response = $this->processRequest($apiParam, $yotpoFormatItemData);
+
+            $response = $this->processRequest($apiRequestParams, $magentoItemData);
 
             $lastSyncTime = $this->getCurrentTime();
             $yotpoIdKey = $isVisibleVariantsSync ? 'visible_variant_yotpo_id' : 'yotpo_id';
             $tempSqlArray = [
                 'product_id' => $itemEntityId,
-                $yotpoIdKey => $apiParam['yotpo_id'] ?: 0,
+                $yotpoIdKey => $apiRequestParams['yotpo_id'] ?: 0,
                 'store_id' => $storeId,
                 'synced_to_yotpo' => $lastSyncTime,
                 'response_code' => $response->getData('status'),
                 'sync_status' => 1
             ];
             if (!$isVisibleVariantsSync) {
-                $tempSqlArray['yotpo_id_parent'] = $apiParam['yotpo_id_parent'] ?: 0;
+                $tempSqlArray['yotpo_id_parent'] = $apiRequestParams['yotpo_id_parent'] ?: 0;
             }
             if ($this->coreConfig->canUpdateCustomAttributeForProducts($tempSqlArray['response_code'])) {
                 if ($this->isSyncingAsMainEntity()) {
@@ -305,7 +306,7 @@ class Processor extends Main
             }
 
             $returnResponse = $this->processResponse(
-                $apiParam,
+                $apiRequestParams,
                 $response,
                 $tempSqlArray,
                 $yotpoFormatItemData,

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -245,7 +245,7 @@ class Processor extends Main
 
         $itemsToBeSyncedToYotpo = $items['sync_data'];
         foreach ($itemsToBeSyncedToYotpo as $itemEntityId => $yotpoFormatItemData) {
-            $rowId = $yotpoFormatItemData['row_id'];
+            $itemRowId = $yotpoFormatItemData['row_id'];
             unset($yotpoFormatItemData['row_id']);
 
             if ($yotpoSyncTableItemsData
@@ -260,7 +260,7 @@ class Processor extends Main
                     'attribute_id' => $syncedToYotpoProductAttributeId,
                     'store_id' => $storeId,
                     'value' => 1,
-                    $this->entityIdFieldValue => $rowId
+                    $this->entityIdFieldValue => $itemRowId
                 ];
                 $sqlDataIntTable = [];
                 $sqlDataIntTable[] = $tempSqlDataIntTable;
@@ -310,7 +310,7 @@ class Processor extends Main
                     'attribute_id' => $syncedToYotpoProductAttributeId,
                     'store_id' => $storeId,
                     'value' => 1,
-                    $this->entityIdFieldValue => $rowId
+                    $this->entityIdFieldValue => $itemRowId
                 ];
                 $sqlDataIntTable = [];
                 $sqlDataIntTable[] = $tempSqlDataIntTable;

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -706,11 +706,21 @@ class Processor extends Main
         return $this->syncDataMain->getProductIds($productIds, $storeId, $itemsMap);
     }
 
+    /**
+     * @param array $yotpoSyncTableItemData
+     * @return bool
+     */
     private function shouldItemBeResynced($yotpoSyncTableItemData)
     {
         return $this->coreConfig->canResync($yotpoSyncTableItemData['response_code'], $yotpoSyncTableItemData, $this->isCommandLineSync);
     }
 
+    /**
+     * @param integer $storeId
+     * @param integer $itemRowId
+     * @param integer $syncedToYotpoProductAttributeId
+     * @return array
+     */
     private function prepareAttributeDataToUpdate($storeId, $itemRowId, $syncedToYotpoProductAttributeId)
     {
         return [
@@ -721,6 +731,15 @@ class Processor extends Main
         ];
     }
 
+    /**
+     * @param integer $itemEntityId
+     * @param string $yotpoIdKey
+     * @param integer $yotpoIdValue
+     * @param integer $storeId
+     * @param integer $responseCode
+     * @param integer $yotpoParentId
+     * @return array
+     */
     private function prepareSyncTableDataToUpdate($itemEntityId, $yotpoIdKey, $yotpoIdValue, $storeId, $responseCode, $yotpoParentId = null)
     {
         $lastSyncTime = $this->getCurrentTime();
@@ -734,6 +753,10 @@ class Processor extends Main
         ];
     }
 
+    /**
+     * @param array $attributeDataToUpdate
+     * @return void
+     */
     private function updateProductSyncAttribute($attributeDataToUpdate) {
         $this->insertOnDuplicate(
             'catalog_product_entity_int',
@@ -741,6 +764,10 @@ class Processor extends Main
         );
     }
 
+    /**
+     * @param array $syncDataRecord
+     * @return void
+     */
     private function updateSyncTable($syncDataRecord) {
         $this->insertOnDuplicate(
             'yotpo_product_sync',

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -285,7 +285,7 @@ class Processor extends Main
 
             $lastSyncTime = $this->getCurrentTime();
             $yotpoIdKey = $isVisibleVariantsSync ? 'visible_variant_yotpo_id' : 'yotpo_id';
-            $tempSqlArray = [
+            $syncDataRecordToUpdate = [
                 'product_id' => $itemEntityId,
                 $yotpoIdKey => $apiRequestParams['yotpo_id'] ?: 0,
                 'store_id' => $storeId,
@@ -294,9 +294,9 @@ class Processor extends Main
                 'sync_status' => 1
             ];
             if (!$isVisibleVariantsSync) {
-                $tempSqlArray['yotpo_id_parent'] = $apiRequestParams['yotpo_id_parent'] ?: 0;
+                $syncDataRecordToUpdate['yotpo_id_parent'] = $apiRequestParams['yotpo_id_parent'] ?: 0;
             }
-            if ($this->coreConfig->canUpdateCustomAttributeForProducts($tempSqlArray['response_code'])) {
+            if ($this->coreConfig->canUpdateCustomAttributeForProducts($syncDataRecordToUpdate['response_code'])) {
                 if ($this->isSyncingAsMainEntity()) {
                     $this->insertOnDuplicate(
                         'catalog_product_entity_int',
@@ -308,13 +308,13 @@ class Processor extends Main
             $returnResponse = $this->processResponse(
                 $apiRequestParams,
                 $response,
-                $tempSqlArray,
+                $syncDataRecordToUpdate,
                 $yotpoFormatItemData,
                 $externalIds,
                 $isVisibleVariantsSync
             );
 
-            $tempSqlArray = $returnResponse['temp_sql'];
+            $syncDataRecordToUpdate = $returnResponse['temp_sql'];
             $externalIds = $returnResponse['external_id'];
 
             if (isset($this->retryItems[$storeId][$itemEntityId])) {
@@ -333,17 +333,17 @@ class Processor extends Main
             //push to parentData array if parent product is
             // being the part of current collection
             if (!$isVisibleVariantsSync) {
-                $parentItemsData = $this->pushParentData((int)$itemEntityId, $tempSqlArray, $parentItemsData, $parentItemsIds);
+                $parentItemsData = $this->pushParentData((int)$itemEntityId, $syncDataRecordToUpdate, $parentItemsData, $parentItemsIds);
             }
 
-            if ($tempSqlArray) {
+            if ($syncDataRecordToUpdate) {
                 $syncDataSql = [];
-                $syncDataSql[] = $tempSqlArray;
+                $syncDataSql[] = $syncDataRecordToUpdate;
                 $this->insertOnDuplicate(
                     'yotpo_product_sync',
                     $syncDataSql
                 );
-                $sqlData[] = $tempSqlArray;
+                $sqlData[] = $syncDataRecordToUpdate;
             }
 
             if ($this->isCommandLineSync && !$this->isImmediateRetry) {

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -238,7 +238,7 @@ class Processor extends Main
         $parentItemsData = $items['parent_data'];
 
         $syncTableRecordsUpdated = [];
-        $externalIds = [];
+        $externalIdsWithConflictResponse = [];
         $visibleVariantsData = $isVisibleVariantsSync ? [] : $items['visible_variants'];
         $visibleVariantsDataValues = array_values($visibleVariantsData);
 
@@ -297,12 +297,12 @@ class Processor extends Main
                 $response,
                 $syncDataRecordToUpdate,
                 $yotpoFormatItemData,
-                $externalIds,
+                $externalIdsWithConflictResponse,
                 $isVisibleVariantsSync
             );
 
             $processedSyncDataRecordToUpdate = $returnResponse['temp_sql'];
-            $externalIds = $returnResponse['external_id'];
+            $externalIdsWithConflictResponse = $returnResponse['external_id'];
 
             if (isset($this->retryItems[$storeId][$itemEntityId])) {
                 unset($this->retryItems[$storeId][$itemEntityId]);
@@ -338,9 +338,9 @@ class Processor extends Main
             $dataToSent = array_merge($dataToSent, $this->catalogData->filterDataForCatSync($syncTableRecordsUpdated));
         }
 
-        if ($externalIds) {
+        if ($externalIdsWithConflictResponse) {
             $yotpoExistingProducts = $this->processExistData(
-                $externalIds,
+                $externalIdsWithConflictResponse,
                 $parentItemsData,
                 $parentItemsIds,
                 $isVisibleVariantsSync

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -236,8 +236,7 @@ class Processor extends Main
         $parentItemsIds = $items['parent_ids'];
         $yotpoSyncTableItemsData = $items['yotpo_data'];
         $parentItemsData = $items['parent_data'];
-
-        $lastSyncTime = '';
+        
         $sqlData = $sqlDataIntTable = [];
         $externalIds = [];
         $visibleVariantsData = $isVisibleVariantsSync ? [] : $items['visible_variants'];
@@ -355,7 +354,7 @@ class Processor extends Main
         }
 
         if ($this->isSyncingAsMainEntity()) {
-            $this->coreConfig->saveConfig('catalog_last_sync_time', $lastSyncTime);
+            $this->coreConfig->saveConfig('catalog_last_sync_time', $this->getCurrentTime());
             $dataForCategorySync = [];
             if ($dataToSent && !$isVisibleVariantsSync) {
                 $dataForCategorySync = $this->getProductsForCategorySync(

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -362,7 +362,7 @@ class Main extends AbstractJobs
      * @param array<int, array> $yotpoData
      * @param array<int, int> $parentIds
      * @param array<int|string, mixed> $parentData
-     * @param boolean $visibleVariants
+     * @param boolean $isVisibleVariant
      * @return array<string, string>
      * @throws NoSuchEntityException
      */
@@ -371,13 +371,13 @@ class Main extends AbstractJobs
         array $yotpoData,
         array $parentIds,
         array $parentData,
-        $visibleVariants = false
+        $isVisibleVariant
     ) {
         $apiUrl = $this->coreConfig->getEndpoint('products');
         $method = $this->coreConfig->getProductSyncMethod('createProduct');
         $yotpoIdParent = $yotpoId = '';
 
-        if (count($parentIds) && !$visibleVariants) {
+        if (count($parentIds) && !$isVisibleVariant) {
             if (isset($parentIds[$productId])
                 && isset($parentData[$parentIds[$productId]])
                 && isset($parentData[$parentIds[$productId]]['yotpo_id'])
@@ -394,7 +394,7 @@ class Main extends AbstractJobs
             }
         }
 
-        $yotpoIdKey = $visibleVariants ? 'visible_variant_yotpo_id' : 'yotpo_id';
+        $yotpoIdKey = $isVisibleVariant ? 'visible_variant_yotpo_id' : 'yotpo_id';
         if (count($yotpoData)) {
             if (isset($yotpoData[$productId])
                 && isset($yotpoData[$productId][$yotpoIdKey])

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -376,9 +376,12 @@ class Main extends AbstractJobs
         $apiUrl = $this->coreConfig->getEndpoint('products');
         $method = $this->coreConfig->getProductSyncMethod('createProduct');
         $yotpoIdParent = $yotpoId = '';
+        $yotpoIdKey = 'yotpo_id';
 
-        if (count($parentIds) && !$isVisibleVariant) {
-            if (isset($parentIds[$productId])
+        if ($isVisibleVariant) {
+            $yotpoIdKey = 'visible_variant_yotpo_id';
+        } else {
+            if (count($parentIds) && isset($parentIds[$productId])
                 && isset($parentData[$parentIds[$productId]])
                 && isset($parentData[$parentIds[$productId]]['yotpo_id'])
                 && $yotpoIdParent = $parentData[$parentIds[$productId]]['yotpo_id']) {
@@ -394,7 +397,6 @@ class Main extends AbstractJobs
             }
         }
 
-        $yotpoIdKey = $isVisibleVariant ? 'visible_variant_yotpo_id' : 'yotpo_id';
         if (count($yotpoData)) {
             if (isset($yotpoData[$productId])
                 && isset($yotpoData[$productId][$yotpoIdKey])

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -380,11 +380,10 @@ class Main extends AbstractJobs
 
         if ($isVisibleVariant) {
             $yotpoIdKey = 'visible_variant_yotpo_id';
-        } else {
-            if (count($parentIds) && isset($parentIds[$productId])
-                && isset($parentData[$parentIds[$productId]])
-                && isset($parentData[$parentIds[$productId]]['yotpo_id'])
-                && $yotpoIdParent = $parentData[$parentIds[$productId]]['yotpo_id']) {
+        } elseif (count($parentIds) && isset($parentIds[$productId])) {
+            $parentId = $parentIds[$productId];
+            if ($this->isProductParentYotpoIdFound($parentData, $parentId)) {
+                $yotpoIdParent = $parentData[$parentId]['yotpo_id'];
 
                 $method = $this->coreConfig->getProductSyncMethod('createProductVariant');
                 $apiUrl = $this->coreConfig->getEndpoint(
@@ -392,7 +391,7 @@ class Main extends AbstractJobs
                     ['{yotpo_product_id}'],
                     [$yotpoIdParent]
                 );
-            } elseif (isset($parentIds[$productId])) {
+            } else {
                 return [];
             }
         }
@@ -637,5 +636,15 @@ class Main extends AbstractJobs
     public function setNormalSyncFlag($flag)
     {
         $this->normalSync = $flag;
+    }
+
+    /**
+     * @param $parentData
+     * @param $parentId
+     * @return bool
+     */
+    public function isProductParentYotpoIdFound($parentData, $parentId): bool
+    {
+        return isset($parentData[$parentId]) && isset($parentData[$parentId]['yotpo_id']);
     }
 }

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -391,8 +391,6 @@ class Main extends AbstractJobs
                     ['{yotpo_product_id}'],
                     [$yotpoIdParent]
                 );
-            } else {
-                return [];
             }
         }
 

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -360,8 +360,8 @@ class Main extends AbstractJobs
      * Get API End URL and API Method
      * @param int|string $productId
      * @param array<int, array> $yotpoData
-     * @param array<int, int> $parentIds
-     * @param array<int|string, mixed> $parentData
+     * @param array<int, int> $parentsIds
+     * @param array<int|string, mixed> $parentsData
      * @param boolean $isVisibleVariant
      * @return array<string, string>
      * @throws NoSuchEntityException
@@ -369,8 +369,8 @@ class Main extends AbstractJobs
     protected function getApiParams(
         $productId,
         array $yotpoData,
-        array $parentIds,
-        array $parentData,
+        array $parentsIds,
+        array $parentsData,
         $isVisibleVariant
     ) {
         $apiUrl = $this->coreConfig->getEndpoint('products');
@@ -380,10 +380,10 @@ class Main extends AbstractJobs
 
         if ($isVisibleVariant) {
             $yotpoIdKey = 'visible_variant_yotpo_id';
-        } elseif (count($parentIds) && isset($parentIds[$productId])) {
-            $parentId = $parentIds[$productId];
-            if ($this->isProductParentYotpoIdFound($parentData, $parentId)) {
-                $yotpoIdParent = $parentData[$parentId]['yotpo_id'];
+        } elseif (count($parentsIds) && isset($parentsIds[$productId])) {
+            $parentId = $parentsIds[$productId];
+            if ($this->isProductParentYotpoIdFound($parentsData, $parentId)) {
+                $yotpoIdParent = $parentsData[$parentId]['yotpo_id'];
 
                 $method = $this->coreConfig->getProductSyncMethod('createProductVariant');
                 $apiUrl = $this->coreConfig->getEndpoint(

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -647,4 +647,12 @@ class Main extends AbstractJobs
     {
         return isset($parentData[$parentId]) && isset($parentData[$parentId]['yotpo_id']);
     }
+
+    /**
+     * @return boolean
+     */
+    protected function isSyncingAsMainEntity()
+    {
+        return $this->normalSync;
+    }
 }

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -639,8 +639,8 @@ class Main extends AbstractJobs
     }
 
     /**
-     * @param $parentData
-     * @param $parentId
+     * @param array $parentData
+     * @param integer $parentId
      * @return bool
      */
     public function isProductParentYotpoIdFound($parentData, $parentId): bool

--- a/Model/Sync/Catalog/YotpoResource.php
+++ b/Model/Sync/Catalog/YotpoResource.php
@@ -85,7 +85,7 @@ class YotpoResource
         }
 
         $return['yotpo_data'] = $yotpoData;
-        $return['parent_data'] = $parentData;
+        $return['parents_data'] = $parentData;
         return $return;
     }
 


### PR DESCRIPTION
## Issue:
Variants (simple non-visible products - grouped or configurable) are not being synced to Yotpo when their parent product was not synced to Yotpo yet. The sync fails.
Since the sync works in batches, if there are many cases like this - the state is unrecoverable.
This issue has effect on catalog sync as well as orders/checkouts sync.

## Developer Notes
This is not PR ready. This on the table solution for variant without parent in Yotpo solution.
This PR is based on this refactoring [branch](https://github.com/YotpoLtd/magento2-module-core/pull/113)
This PR also should also be merged it will be merged after this [PR](https://github.com/YotpoLtd/magento2-module-core/pull/99) for minimal product creation fallback.
