### PR TITLE
COR-1983 Create parent product for variant if missing

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -36,6 +36,7 @@ class Config
     const METHOD_PATCH = 'PATCH';
     const CUSTOM_RESPONSE_DATA = '000';
     const SUCCESS_RESPONSE_CODE = '200';
+    const CREATED_STATUS_CODE = '201';
     const BAD_REQUEST_RESPONSE_CODE = 400;
 
     /**

--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -198,8 +198,8 @@ class Data extends Main
     {
         $return = [
             'sync_data' => [],
-            'parent_ids' => [],
-            'parent_data' => []
+            'parents_ids' => [],
+            'parents_data' => []
         ];
         $syncItems = $productsId = $productsObject = [];
         foreach ($items as $item) {
@@ -223,10 +223,10 @@ class Data extends Main
             }
         }
         $return['sync_data'] = $syncItems;
-        $return['parent_ids'] = $parentIds;
+        $return['parents_ids'] = $parentIds;
         $yotpoData = $this->fetchYotpoData($productsId, $parentIds);
         $return['yotpo_data'] = $yotpoData['yotpo_data'];
-        $return['parent_data'] = $yotpoData['parent_data'];
+        $return['parents_data'] = $yotpoData['parents_data'];
         $return['visible_variants'] = $visibleVariantsData;
         return $return;
     }

--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -329,7 +329,7 @@ class Data extends Main
      * @return array<string, string|array>
      * @throws NoSuchEntityException
      */
-    protected function attributeMapping(Product $item)
+    public function attributeMapping(Product $item)
     {
         $itemArray = [];
         $mapAttributes = $this->mappingAttributes;

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -22,6 +22,7 @@ use Yotpo\Core\Api\ProductSyncRepositoryInterface;
  */
 class Processor extends Main
 {
+
     /**
      * @var CatalogData
      */
@@ -233,9 +234,9 @@ class Processor extends Main
 
         $syncedToYotpoProductAttributeId = $this->catalogData->getAttributeId(CoreConfig::CATALOG_SYNC_ATTR_CODE);
         $items = $this->getSyncItems($collectionItems, $isVisibleVariantsSync);
-        $parentItemsIds = $items['parent_ids'];
+        $parentItemsIds = $items['parents_ids'];
         $yotpoSyncTableItemsData = $items['yotpo_data'];
-        $parentItemsData = $items['parent_data'];
+        $parentItemsData = $items['parents_data'];
 
         $syncTableRecordsUpdated = [];
         $externalIdsWithConflictResponse = [];
@@ -512,66 +513,66 @@ class Processor extends Main
      * Push Yotpo Id to Parent data
      * @param int $productId
      * @param array<string, int|string> $tempSqlArray
-     * @param array<int|string, mixed> $parentData
-     * @param array<int, int> $parentIds
+     * @param array<int|string, mixed> $parentsData
+     * @param array<int, int> $parentsIds
      * @return array<int|string, mixed>
      */
-    protected function pushParentData($productId, $tempSqlArray, $parentData, $parentIds)
+    protected function pushParentData($productId, $tempSqlArray, $parentsData, $parentsIds)
     {
         $yotpoId = 0;
         if (isset($tempSqlArray['yotpo_id'])
             && $tempSqlArray['yotpo_id']) {
-            if (!isset($parentData[$productId])) {
-                $parentId = $this->findParentId($productId, $parentIds);
+            if (!isset($parentsData[$productId])) {
+                $parentId = $this->findParentId($productId, $parentsIds);
                 if ($parentId) {
                     $yotpoId = $tempSqlArray['yotpo_id'];
                 }
             }
         }
         if ($yotpoId) {
-            $parentData[$productId] = [
+            $parentsData[$productId] = [
                 'product_id' => $productId,
                 'yotpo_id' => $yotpoId
             ];
         }
 
-        return $parentData;
+        return $parentsData;
     }
 
     /**
      * Find it parent ID is exist in the synced data
      * @param int $productId
-     * @param array<int, int> $parentIds
+     * @param array<int, int> $parentsIds
      * @return false|int|string
      */
-    protected function findParentId($productId, $parentIds)
+    protected function findParentId($productId, $parentsIds)
     {
-        return array_search($productId, $parentIds);
+        return array_search($productId, $parentsIds);
     }
 
     /**
      * Fetch Existing data and update the product_sync table
      *
      * @param array<int, int|string> $externalIds
-     * @param array<int|string, mixed> $parentData
-     * @param array<int, int> $parentIds
+     * @param array<int|string, mixed> $parentsData
+     * @param array<int, int> $parentsIds
      * @param boolean $visibleVariants
      * @return array<mixed>
      * @throws NoSuchEntityException
      */
     protected function processExistData(
         array $externalIds,
-        array $parentData,
-        array $parentIds,
+        array $parentsData,
+        array $parentsIds,
         $visibleVariants = false
     ) {
         $sqlData = $filters = [];
         if (count($externalIds) > 0) {
             foreach ($externalIds as $externalId) {
-                if (isset($parentIds[$externalId]) && $parentIds[$externalId] && !$visibleVariants) {
-                    if (isset($parentData[$parentIds[$externalId]]) &&
-                        isset($parentData[$parentIds[$externalId]]['yotpo_id']) &&
-                        $parentYotpoId = $parentData[$parentIds[$externalId]]['yotpo_id']) {
+                if (isset($parentsIds[$externalId]) && $parentsIds[$externalId] && !$visibleVariants) {
+                    if (isset($parentsData[$parentsIds[$externalId]]) &&
+                        isset($parentsData[$parentsIds[$externalId]]['yotpo_id']) &&
+                        $parentYotpoId = $parentsData[$parentsIds[$externalId]]['yotpo_id']) {
                         $filters['variants'][$parentYotpoId][] = $externalId;
                     } else {
                         $filters['products'][] = $externalId;
@@ -709,7 +710,6 @@ class Processor extends Main
         $unSyncedProductIds = $this->getUnSyncedProductIds($productIds, $visibleItems, $storeId);
         if ($unSyncedProductIds) {
             $this->setNormalSyncFlag(false);
-            $unSyncedProductIds = [$storeId => $unSyncedProductIds];
             $sync = $this->process($unSyncedProductIds, [$storeId]);
             $this->emulateFrontendArea($storeId);
             return $sync;

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -391,8 +391,6 @@ class Main extends AbstractJobs
                     ['{yotpo_product_id}'],
                     [$yotpoIdParent]
                 );
-            } else {
-                return [];
             }
         }
 

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -360,8 +360,8 @@ class Main extends AbstractJobs
      * Get API End URL and API Method
      * @param int|string $productId
      * @param array<int, array> $yotpoData
-     * @param array<int, int> $parentIds
-     * @param array<int|string, mixed> $parentData
+     * @param array<int, int> $parentsIds
+     * @param array<int|string, mixed> $parentsData
      * @param boolean $isVisibleVariant
      * @return array<string, string>
      * @throws NoSuchEntityException
@@ -369,8 +369,8 @@ class Main extends AbstractJobs
     protected function getApiParams(
         $productId,
         array $yotpoData,
-        array $parentIds,
-        array $parentData,
+        array $parentsIds,
+        array $parentsData,
         $isVisibleVariant
     ) {
         $apiUrl = $this->coreConfig->getEndpoint('products');
@@ -380,10 +380,10 @@ class Main extends AbstractJobs
 
         if ($isVisibleVariant) {
             $yotpoIdKey = 'visible_variant_yotpo_id';
-        } elseif (count($parentIds) && isset($parentIds[$productId])) {
-            $parentId = $parentIds[$productId];
-            if ($this->isProductParentYotpoIdFound($parentData, $parentId)) {
-                $yotpoIdParent = $parentData[$parentId]['yotpo_id'];
+        } elseif (count($parentsIds) && isset($parentsIds[$productId])) {
+            $parentId = $parentsIds[$productId];
+            if ($this->isProductParentYotpoIdFound($parentsData, $parentId)) {
+                $yotpoIdParent = $parentsData[$parentId]['yotpo_id'];
 
                 $method = $this->coreConfig->getProductSyncMethod('createProductVariant');
                 $apiUrl = $this->coreConfig->getEndpoint(

--- a/Model/Sync/Catalog/YotpoResource.php
+++ b/Model/Sync/Catalog/YotpoResource.php
@@ -85,7 +85,7 @@ class YotpoResource
         }
 
         $return['yotpo_data'] = $yotpoData;
-        $return['parent_data'] = $parentData;
+        $return['parents_data'] = $parentData;
         return $return;
     }
 


### PR DESCRIPTION
**Moved to #138** 

## Issue:
Variants (simple non-visible products - grouped or configurable) are not being synced to Yotpo when their parent product was not synced to Yotpo yet. The sync fails.
Since the sync works in batches, if there are many cases like this - the state is unrecoverable.
This issue has effect on catalog sync as well as orders/checkouts sync.

## Developer Notes
This is not PR ready. This on the table solution for variant without parent in Yotpo solution.
This PR is based on this refactoring [branch](https://github.com/YotpoLtd/magento2-module-core/pull/113)
This PR also should also be merged it will be merged after this [PR](https://github.com/YotpoLtd/magento2-module-core/pull/99) for minimal product creation fallback.
