### PR TITLE
COR Variants catalog fixes

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -36,6 +36,7 @@ class Config
     const METHOD_PATCH = 'PATCH';
     const CUSTOM_RESPONSE_DATA = '000';
     const SUCCESS_RESPONSE_CODE = '200';
+    const CREATED_STATUS_CODE = '201';
     const BAD_REQUEST_RESPONSE_CODE = 400;
 
     /**

--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -327,7 +327,7 @@ class Data extends Main
      * @return array<string, string|array>
      * @throws NoSuchEntityException
      */
-    protected function attributeMapping(Product $item)
+    public function attributeMapping(Product $item)
     {
         $itemArray = [];
         $mapAttributes = $this->mappingAttributes;

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -406,8 +406,6 @@ class Main extends AbstractJobs
                     ['{yotpo_product_id}'],
                     [$yotpoIdParent]
                 );
-            } else {
-                return [];
             }
         }
 


### PR DESCRIPTION
## Issue
**Original PR - #133**
**Author - @DanielxC** 

#### Description
Variants (simple non-visible products - grouped or configurable) are not being synced to Yotpo when their parent product was not synced to Yotpo yet. The sync fails.
Since the sync works in batches, if there are more cases like this than the batch size - the state is unrecoverable and will loop forever.
This issue has an effect on catalog sync so it impacts orders/checkouts sync as well.

#### Developer Notes
Implemented the following logic:
If we're trying to sync a variant that its parent product is not synced to Yotpo, sync the parent product to Yotpo immediately.