### PR TITLE
COR fixed catalog sync failure indication and minimal product support

### DIFF
--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -198,8 +198,8 @@ class Data extends Main
     {
         $return = [
             'sync_data' => [],
-            'parent_ids' => [],
-            'parent_data' => []
+            'parents_ids' => [],
+            'parents_data' => []
         ];
         $syncItems = $productsId = $productsObject = [];
         foreach ($items as $item) {
@@ -223,10 +223,10 @@ class Data extends Main
             }
         }
         $return['sync_data'] = $syncItems;
-        $return['parent_ids'] = $parentIds;
+        $return['parents_ids'] = $parentIds;
         $yotpoData = $this->fetchYotpoData($productsId, $parentIds);
         $return['yotpo_data'] = $yotpoData['yotpo_data'];
-        $return['parent_data'] = $yotpoData['parent_data'];
+        $return['parents_data'] = $yotpoData['parents_data'];
         $return['visible_variants'] = $visibleVariantsData;
         return $return;
     }

--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -523,4 +523,13 @@ class Data extends Main
         return trim($item->getData('description')) ?:
             trim($item->getData('short_description'));
     }
+
+    /**
+     * @param array<string, mixed> $yotpoItemData
+     * @return array<string, integer>
+     */
+    public function getMinimalProductRequestData($yotpoItemData) {
+        $externalId = $yotpoItemData['external_id'];
+        return ['external_id' => $externalId];
+    }
 }

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -23,11 +23,6 @@ use Yotpo\Core\Api\ProductSyncRepositoryInterface;
 class Processor extends Main
 {
     /**
-     * @var CatalogData
-     */
-    protected $catalogData;
-
-    /**
      * @var SyncDataMain
      */
     protected $syncDataMain;
@@ -98,9 +93,9 @@ class Processor extends Main
             $yotpoCatalogLogger,
             $yotpoResource,
             $collectionFactory,
-            $coreSync
+            $coreSync,
+            $catalogData
         );
-        $this->catalogData = $catalogData;
         $this->dateTime = $dateTime;
         $this->categorySyncProcessor = $categorySyncProcessor;
         $this->productSyncRepositoryInterface = $productSyncRepositoryInterface;

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -22,6 +22,7 @@ use Yotpo\Core\Api\ProductSyncRepositoryInterface;
  */
 class Processor extends Main
 {
+
     /**
      * @var SyncDataMain
      */
@@ -228,9 +229,9 @@ class Processor extends Main
 
         $syncedToYotpoProductAttributeId = $this->catalogData->getAttributeId(CoreConfig::CATALOG_SYNC_ATTR_CODE);
         $items = $this->getSyncItems($collectionItems, $isVisibleVariantsSync);
-        $parentItemsIds = $items['parent_ids'];
+        $parentItemsIds = $items['parents_ids'];
         $yotpoSyncTableItemsData = $items['yotpo_data'];
-        $parentItemsData = $items['parent_data'];
+        $parentItemsData = $items['parents_data'];
 
         $syncTableRecordsUpdated = [];
         $externalIdsWithConflictResponse = [];
@@ -507,66 +508,66 @@ class Processor extends Main
      * Push Yotpo Id to Parent data
      * @param int $productId
      * @param array<string, int|string> $tempSqlArray
-     * @param array<int|string, mixed> $parentData
-     * @param array<int, int> $parentIds
+     * @param array<int|string, mixed> $parentsData
+     * @param array<int, int> $parentsIds
      * @return array<int|string, mixed>
      */
-    protected function pushParentData($productId, $tempSqlArray, $parentData, $parentIds)
+    protected function pushParentData($productId, $tempSqlArray, $parentsData, $parentsIds)
     {
         $yotpoId = 0;
         if (isset($tempSqlArray['yotpo_id'])
             && $tempSqlArray['yotpo_id']) {
-            if (!isset($parentData[$productId])) {
-                $parentId = $this->findParentId($productId, $parentIds);
+            if (!isset($parentsData[$productId])) {
+                $parentId = $this->findParentId($productId, $parentsIds);
                 if ($parentId) {
                     $yotpoId = $tempSqlArray['yotpo_id'];
                 }
             }
         }
         if ($yotpoId) {
-            $parentData[$productId] = [
+            $parentsData[$productId] = [
                 'product_id' => $productId,
                 'yotpo_id' => $yotpoId
             ];
         }
 
-        return $parentData;
+        return $parentsData;
     }
 
     /**
      * Find it parent ID is exist in the synced data
      * @param int $productId
-     * @param array<int, int> $parentIds
+     * @param array<int, int> $parentsIds
      * @return false|int|string
      */
-    protected function findParentId($productId, $parentIds)
+    protected function findParentId($productId, $parentsIds)
     {
-        return array_search($productId, $parentIds);
+        return array_search($productId, $parentsIds);
     }
 
     /**
      * Fetch Existing data and update the product_sync table
      *
      * @param array<int, int|string> $externalIds
-     * @param array<int|string, mixed> $parentData
-     * @param array<int, int> $parentIds
+     * @param array<int|string, mixed> $parentsData
+     * @param array<int, int> $parentsIds
      * @param boolean $visibleVariants
      * @return array<mixed>
      * @throws NoSuchEntityException
      */
     protected function processExistData(
         array $externalIds,
-        array $parentData,
-        array $parentIds,
+        array $parentsData,
+        array $parentsIds,
         $visibleVariants = false
     ) {
         $sqlData = $filters = [];
         if (count($externalIds) > 0) {
             foreach ($externalIds as $externalId) {
-                if (isset($parentIds[$externalId]) && $parentIds[$externalId] && !$visibleVariants) {
-                    if (isset($parentData[$parentIds[$externalId]]) &&
-                        isset($parentData[$parentIds[$externalId]]['yotpo_id']) &&
-                        $parentYotpoId = $parentData[$parentIds[$externalId]]['yotpo_id']) {
+                if (isset($parentsIds[$externalId]) && $parentsIds[$externalId] && !$visibleVariants) {
+                    if (isset($parentsData[$parentsIds[$externalId]]) &&
+                        isset($parentsData[$parentsIds[$externalId]]['yotpo_id']) &&
+                        $parentYotpoId = $parentsData[$parentsIds[$externalId]]['yotpo_id']) {
                         $filters['variants'][$parentYotpoId][] = $externalId;
                     } else {
                         $filters['products'][] = $externalId;

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -375,8 +375,8 @@ class Main extends AbstractJobs
      * Get API End URL and API Method
      * @param int|string $productId
      * @param array<int, array> $yotpoData
-     * @param array<int, int> $parentIds
-     * @param array<int|string, mixed> $parentData
+     * @param array<int, int> $parentsIds
+     * @param array<int|string, mixed> $parentsData
      * @param boolean $isVisibleVariant
      * @return array<string, string>
      * @throws NoSuchEntityException
@@ -384,8 +384,8 @@ class Main extends AbstractJobs
     protected function getApiParams(
         $productId,
         array $yotpoData,
-        array $parentIds,
-        array $parentData,
+        array $parentsIds,
+        array $parentsData,
         $isVisibleVariant
     ) {
         $apiUrl = $this->coreConfig->getEndpoint('products');
@@ -395,10 +395,10 @@ class Main extends AbstractJobs
 
         if ($isVisibleVariant) {
             $yotpoIdKey = 'visible_variant_yotpo_id';
-        } elseif (count($parentIds) && isset($parentIds[$productId])) {
-            $parentId = $parentIds[$productId];
-            if ($this->isProductParentYotpoIdFound($parentData, $parentId)) {
-                $yotpoIdParent = $parentData[$parentId]['yotpo_id'];
+        } elseif (count($parentsIds) && isset($parentsIds[$productId])) {
+            $parentId = $parentsIds[$productId];
+            if ($this->isProductParentYotpoIdFound($parentsData, $parentId)) {
+                $yotpoIdParent = $parentsData[$parentId]['yotpo_id'];
 
                 $method = $this->coreConfig->getProductSyncMethod('createProductVariant');
                 $apiUrl = $this->coreConfig->getEndpoint(

--- a/Model/Sync/Catalog/YotpoResource.php
+++ b/Model/Sync/Catalog/YotpoResource.php
@@ -85,7 +85,7 @@ class YotpoResource
         }
 
         $return['yotpo_data'] = $yotpoData;
-        $return['parent_data'] = $parentData;
+        $return['parents_data'] = $parentData;
         return $return;
     }
 


### PR DESCRIPTION
## Issue 1 - Feature
**Original PR - #132** 
**Author - @LiorGingi** 

#### Description
Orders and Checkouts sync failed if product creation process returned 400 response.

#### Developer Notes
Implemented a logic of creating a minimal product (a product with external ID only) if the creation process failed.

## Issue 2 - Bug
**Original PR - #137**
**Author - @LiorGingi** 

#### Description
YClient is catching GuzzleException, which leads the product processor to return a misleading indication that product creation sync was successful.
Due to that, the orders/checkouts sync processes will fail as they'll continue the process while the products are missing in Yotpo. 

#### Developer Notes
Implemented the following logic:
A boolean is returned from the syncItems method, indicating If any product failed the **creation** process.
This is because we don't want to fail orders/checkouts sync for update events (the products already exist in Yotpo).