### PR TITLE
COR-2000 Revamp collections products sync flows

### DIFF
--- a/Model/Config.php
+++ b/Model/Config.php
@@ -44,6 +44,8 @@ class Config
     const NOT_FOUND_RESPONSE_CODE = 404;
     const CONFLICT_RESPONSE_CODE = 409;
 
+    const YOTPO_SYNC_RESPONSE_IS_SUCCESS_KEY = 'is_success';
+
     /**
      * @var mixed[]
      */
@@ -541,14 +543,14 @@ class Config
 
     /**
      * Check if Yotpo is enabled and if order sync is active.
-     *
+     * @param int|null $storeId
      * @return bool
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function isCatalogSyncActive()
+    public function isCatalogSyncActive($storeId = null)
     {
-        return ($this->isEnabled() && $this->getConfig('catalog_sync_enable'));
+        return ($this->isEnabled($storeId) && $this->getConfig('catalog_sync_enable', $storeId));
     }
 
     /**
@@ -596,6 +598,19 @@ class Config
     public function isSingleStoreMode()
     {
         return $this->storeManager->isSingleStoreMode();
+    }
+
+    /**
+     * @param mixed $response
+     * @return boolean
+     */
+    public function isResponseIndicatesSuccess($response)
+    {
+        if ($response && $response->getData($this::YOTPO_SYNC_RESPONSE_IS_SUCCESS_KEY)) {
+            return $response->getData($this::YOTPO_SYNC_RESPONSE_IS_SUCCESS_KEY);
+        }
+
+        return false;
     }
 
     /**
@@ -677,5 +692,9 @@ class Config
     public function getYotpoRetryAttemptsAmount(): int
     {
         return self::YOTPO_RETRY_ATTEMPTS_AMOUNT;
+    }
+
+    public function getSuccessfulResponseCodes() {
+        return $this->successfulResponseCodes;
     }
 }

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -36,10 +36,13 @@ class Config
     const METHOD_GET = 'GET';
     const METHOD_POST = 'POST';
     const METHOD_PATCH = 'PATCH';
+    const METHOD_DELETE = 'DELETE';
     const CUSTOM_RESPONSE_DATA = '000';
     const SUCCESS_RESPONSE_CODE = '200';
     const CREATED_STATUS_CODE = '201';
     const BAD_REQUEST_RESPONSE_CODE = 400;
+    const NOT_FOUND_RESPONSE_CODE = 404;
+    const CONFLICT_RESPONSE_CODE = 409;
 
     /**
      * @var mixed[]

--- a/Model/CronConfig.php
+++ b/Model/CronConfig.php
@@ -121,10 +121,10 @@ class CronConfig extends Value
             )->setPath(
                 self::CRON_MODEL_PATH_CATEGORY
             )->save();
-        } catch (\Exception $e) {
+        } catch (\Exception $exception) {
             throw new CouldNotSaveException(
                 __('We can\'t save the cron expression.'),
-                $e
+                $exception
             );
         }
 

--- a/Model/CronConfig.php
+++ b/Model/CronConfig.php
@@ -82,11 +82,11 @@ class CronConfig extends Value
      */
     public function afterSave()
     {
-        $cronExprString = $this->getData('groups/sync_settings/groups/catalog_sync/fields/frequency/value');
+        $catalogCronExpressionString = $this->getData('groups/sync_settings/groups/catalog_sync/fields/frequency/value');
         try {
-            $this->configureCronProductsSync($cronExprString);
+            $this->configureCronProductsSync($catalogCronExpressionString);
 
-            $this->configureCronCategorySync($cronExprString);
+            $this->configureCronCategorySync($catalogCronExpressionString);
         } catch (\Exception $exception) {
             throw new CouldNotSaveException(
                 __('We can\'t save the cron expression.'),
@@ -98,17 +98,17 @@ class CronConfig extends Value
     }
 
     /**
-     * @param string $cronExprString
+     * @param string $catalogCronExpressionString
      * @return void
      */
-    private function configureCronProductsSync($cronExprString)
+    private function configureCronProductsSync($catalogCronExpressionString)
     {
         /** @phpstan-ignore-next-line */
         $this->configValueFactory->create()->load(
             self::CRON_STRING_PATH_PRODUCTS,
             'path'
         )->setValue(
-            $cronExprString
+            $catalogCronExpressionString
         )->setPath(
             self::CRON_STRING_PATH_PRODUCTS
         )->save();
@@ -124,17 +124,17 @@ class CronConfig extends Value
     }
 
     /**
-     * @param string $cronExprString
+     * @param string $catalogCronExpressionString
      * @return void
      */
-    private function configureCronCategorySync($cronExprString)
+    private function configureCronCategorySync($catalogCronExpressionString)
     {
         /** @phpstan-ignore-next-line */
         $this->configValueFactory->create()->load(
             self::CRON_STRING_PATH_CATEGORY,
             'path'
         )->setValue(
-            $cronExprString
+            $catalogCronExpressionString
         )->setPath(
             self::CRON_STRING_PATH_CATEGORY
         )->save();

--- a/Model/CronConfig.php
+++ b/Model/CronConfig.php
@@ -38,6 +38,11 @@ class CronConfig extends Value
     const CATEGORY_SYNC_CRON_PATH = 'crontab/yotpo_core_catalog_sync/jobs/yotpo_cron_core_category_sync';
 
     /**
+     * Collections Products sync Cron job path
+     */
+    const COLLECTIONS_PRODUCTS_SYNC_CRON_PATH = 'crontab/yotpo_core_catalog_sync/jobs/yotpo_cron_core_collections_products_sync';
+
+    /**
      * @var ValueFactory
      */
     protected $configValueFactory;
@@ -87,6 +92,8 @@ class CronConfig extends Value
             $this->configureCronProductsSync($catalogCronExpressionString);
 
             $this->configureCronCategorySync($catalogCronExpressionString);
+
+            $this->configureCronCollectionsProductsSync($catalogCronExpressionString);
         } catch (\Exception $exception) {
             throw new CouldNotSaveException(
                 __('We can\'t save the cron expression.'),
@@ -146,6 +153,32 @@ class CronConfig extends Value
             $this->runModelPath
         )->setPath(
             self::CATEGORY_SYNC_CRON_PATH . self::CRON_MODEL_PATH
+        )->save();
+    }
+
+    /**
+     * @param string $catalogCronExpressionString
+     * @return void
+     */
+    private function configureCronCollectionsProductsSync($catalogCronExpressionString)
+    {
+        /** @phpstan-ignore-next-line */
+        $this->configValueFactory->create()->load(
+            self::COLLECTIONS_PRODUCTS_SYNC_CRON_PATH . self::CRON_EXPRESSION_PATH,
+            'path'
+        )->setValue(
+            $catalogCronExpressionString
+        )->setPath(
+            self::COLLECTIONS_PRODUCTS_SYNC_CRON_PATH . self::CRON_EXPRESSION_PATH
+        )->save();
+        /** @phpstan-ignore-next-line */
+        $this->configValueFactory->create()->load(
+            self::COLLECTIONS_PRODUCTS_SYNC_CRON_PATH . self::CRON_MODEL_PATH,
+            'path'
+        )->setValue(
+            $this->runModelPath
+        )->setPath(
+            self::COLLECTIONS_PRODUCTS_SYNC_CRON_PATH . self::CRON_MODEL_PATH
         )->save();
     }
 }

--- a/Model/CronConfig.php
+++ b/Model/CronConfig.php
@@ -19,23 +19,23 @@ class CronConfig extends Value
     /**
      * Cron expression configuration path
      */
-    const CRON_STRING_PATH_PRODUCTS = 'crontab/yotpo_core_catalog_sync/jobs/yotpo_cron_core_products_sync/schedule/cron_expr';
+    const CRON_EXPRESSION_PATH = '/schedule/cron_expr';
 
     /**
      * Cron expression model path
      */
-    const CRON_MODEL_PATH_PRODUCTS = 'crontab/yotpo_core_catalog_sync/jobs/yotpo_cron_core_products_sync/run/model';
+    const CRON_MODEL_PATH = '/run/model';
 
     /**
-     * Cron expression configuration path
+     * Products sync Cron job path
      */
     // phpcs:ignore
-    const CRON_STRING_PATH_CATEGORY = 'crontab/yotpo_core_catalog_sync/jobs/yotpo_cron_core_category_sync/schedule/cron_expr';
+    const PRODUCTS_SYNC_CRON_PATH = 'crontab/yotpo_core_catalog_sync/jobs/yotpo_cron_core_products_sync';
 
     /**
-     * Cron expression model path
+     * Category sync Cron job path
      */
-    const CRON_MODEL_PATH_CATEGORY = 'crontab/yotpo_core_catalog_sync/jobs/yotpo_cron_core_category_sync/run/model';
+    const CATEGORY_SYNC_CRON_PATH = 'crontab/yotpo_core_catalog_sync/jobs/yotpo_cron_core_category_sync';
 
     /**
      * @var ValueFactory
@@ -105,21 +105,21 @@ class CronConfig extends Value
     {
         /** @phpstan-ignore-next-line */
         $this->configValueFactory->create()->load(
-            self::CRON_STRING_PATH_PRODUCTS,
+            self::PRODUCTS_SYNC_CRON_PATH . self::CRON_EXPRESSION_PATH,
             'path'
         )->setValue(
             $catalogCronExpressionString
         )->setPath(
-            self::CRON_STRING_PATH_PRODUCTS
+            self::PRODUCTS_SYNC_CRON_PATH . self::CRON_EXPRESSION_PATH
         )->save();
          /** @phpstan-ignore-next-line */
         $this->configValueFactory->create()->load(
-            self::CRON_MODEL_PATH_PRODUCTS,
+            self::PRODUCTS_SYNC_CRON_PATH . self::CRON_MODEL_PATH,
             'path'
         )->setValue(
             $this->runModelPath
         )->setPath(
-            self::CRON_MODEL_PATH_PRODUCTS
+            self::PRODUCTS_SYNC_CRON_PATH . self::CRON_MODEL_PATH
         )->save();
     }
 
@@ -131,21 +131,21 @@ class CronConfig extends Value
     {
         /** @phpstan-ignore-next-line */
         $this->configValueFactory->create()->load(
-            self::CRON_STRING_PATH_CATEGORY,
+            self::CATEGORY_SYNC_CRON_PATH . self::CRON_EXPRESSION_PATH,
             'path'
         )->setValue(
             $catalogCronExpressionString
         )->setPath(
-            self::CRON_STRING_PATH_CATEGORY
+            self::CATEGORY_SYNC_CRON_PATH . self::CRON_EXPRESSION_PATH
         )->save();
         /** @phpstan-ignore-next-line */
         $this->configValueFactory->create()->load(
-            self::CRON_MODEL_PATH_CATEGORY,
+            self::CATEGORY_SYNC_CRON_PATH . self::CRON_MODEL_PATH,
             'path'
         )->setValue(
             $this->runModelPath
         )->setPath(
-            self::CRON_MODEL_PATH_CATEGORY
+            self::CATEGORY_SYNC_CRON_PATH . self::CRON_MODEL_PATH
         )->save();
     }
 }

--- a/Model/CronConfig.php
+++ b/Model/CronConfig.php
@@ -19,12 +19,12 @@ class CronConfig extends Value
     /**
      * Cron expression configuration path
      */
-    const CRON_STRING_PATH = 'crontab/yotpo_core_catalog_sync/jobs/yotpo_cron_core_products_sync/schedule/cron_expr';
+    const CRON_STRING_PATH_PRODUCTS = 'crontab/yotpo_core_catalog_sync/jobs/yotpo_cron_core_products_sync/schedule/cron_expr';
 
     /**
      * Cron expression model path
      */
-    const CRON_MODEL_PATH = 'crontab/yotpo_core_catalog_sync/jobs/yotpo_cron_core_products_sync/run/model';
+    const CRON_MODEL_PATH_PRODUCTS = 'crontab/yotpo_core_catalog_sync/jobs/yotpo_cron_core_products_sync/run/model';
 
     /**
      * Cron expression configuration path
@@ -86,21 +86,21 @@ class CronConfig extends Value
         try {
             /** @phpstan-ignore-next-line */
             $this->configValueFactory->create()->load(
-                self::CRON_STRING_PATH,
+                self::CRON_STRING_PATH_PRODUCTS,
                 'path'
             )->setValue(
                 $cronExprString
             )->setPath(
-                self::CRON_STRING_PATH
+                self::CRON_STRING_PATH_PRODUCTS
             )->save();
             /** @phpstan-ignore-next-line */
             $this->configValueFactory->create()->load(
-                self::CRON_MODEL_PATH,
+                self::CRON_MODEL_PATH_PRODUCTS,
                 'path'
             )->setValue(
                 $this->runModelPath
             )->setPath(
-                self::CRON_MODEL_PATH
+                self::CRON_MODEL_PATH_PRODUCTS
             )->save();
 
             /** @phpstan-ignore-next-line */

--- a/Model/CronConfig.php
+++ b/Model/CronConfig.php
@@ -84,43 +84,9 @@ class CronConfig extends Value
     {
         $cronExprString = $this->getData('groups/sync_settings/groups/catalog_sync/fields/frequency/value');
         try {
-            /** @phpstan-ignore-next-line */
-            $this->configValueFactory->create()->load(
-                self::CRON_STRING_PATH_PRODUCTS,
-                'path'
-            )->setValue(
-                $cronExprString
-            )->setPath(
-                self::CRON_STRING_PATH_PRODUCTS
-            )->save();
-            /** @phpstan-ignore-next-line */
-            $this->configValueFactory->create()->load(
-                self::CRON_MODEL_PATH_PRODUCTS,
-                'path'
-            )->setValue(
-                $this->runModelPath
-            )->setPath(
-                self::CRON_MODEL_PATH_PRODUCTS
-            )->save();
+            $this->configureCronProductsSync($cronExprString);
 
-            /** @phpstan-ignore-next-line */
-            $this->configValueFactory->create()->load(
-                self::CRON_STRING_PATH_CATEGORY,
-                'path'
-            )->setValue(
-                $cronExprString
-            )->setPath(
-                self::CRON_STRING_PATH_CATEGORY
-            )->save();
-            /** @phpstan-ignore-next-line */
-            $this->configValueFactory->create()->load(
-                self::CRON_MODEL_PATH_CATEGORY,
-                'path'
-            )->setValue(
-                $this->runModelPath
-            )->setPath(
-                self::CRON_MODEL_PATH_CATEGORY
-            )->save();
+            $this->configureCronCategorySync($cronExprString);
         } catch (\Exception $exception) {
             throw new CouldNotSaveException(
                 __('We can\'t save the cron expression.'),
@@ -129,5 +95,57 @@ class CronConfig extends Value
         }
 
         return parent::afterSave();
+    }
+
+    /**
+     * @param string $cronExprString
+     * @return void
+     */
+    private function configureCronProductsSync($cronExprString)
+    {
+        /** @phpstan-ignore-next-line */
+        $this->configValueFactory->create()->load(
+            self::CRON_STRING_PATH_PRODUCTS,
+            'path'
+        )->setValue(
+            $cronExprString
+        )->setPath(
+            self::CRON_STRING_PATH_PRODUCTS
+        )->save();
+         /** @phpstan-ignore-next-line */
+        $this->configValueFactory->create()->load(
+            self::CRON_MODEL_PATH_PRODUCTS,
+            'path'
+        )->setValue(
+            $this->runModelPath
+        )->setPath(
+            self::CRON_MODEL_PATH_PRODUCTS
+        )->save();
+    }
+
+    /**
+     * @param string $cronExprString
+     * @return void
+     */
+    private function configureCronCategorySync($cronExprString)
+    {
+        /** @phpstan-ignore-next-line */
+        $this->configValueFactory->create()->load(
+            self::CRON_STRING_PATH_CATEGORY,
+            'path'
+        )->setValue(
+            $cronExprString
+        )->setPath(
+            self::CRON_STRING_PATH_CATEGORY
+        )->save();
+        /** @phpstan-ignore-next-line */
+        $this->configValueFactory->create()->load(
+            self::CRON_MODEL_PATH_CATEGORY,
+            'path'
+        )->setValue(
+            $this->runModelPath
+        )->setPath(
+            self::CRON_MODEL_PATH_CATEGORY
+        )->save();
     }
 }

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -19,6 +19,8 @@ use Yotpo\Core\Model\Api\Sync as CoreSync;
  */
 class Main extends AbstractJobs
 {
+    const YOTPO_PRODUCT_SYNC_TABLE_NAME = 'yotpo_product_sync';
+
     /**
      * @var CoreConfig
      */
@@ -692,6 +694,59 @@ class Main extends AbstractJobs
         return isset($yotpoData[$parentId]) &&
             isset($yotpoData[$parentId]['yotpo_id']) &&
             $yotpoData[$parentId]['yotpo_id'];
+    }
+
+    /**
+     * @param string $productId
+     * @return string
+     */
+    public function getYotpoIdFromProductsSyncTableByProductId($productId) {
+        $storeId = $this->coreConfig->getStoreId();
+        $connection = $this->resourceConnection->getConnection();
+        $productYotpoIdQuery = $connection->select(
+        )->from(
+            [ $this->resourceConnection->getTableName($this::YOTPO_PRODUCT_SYNC_TABLE_NAME) ],
+            [ 'yotpo_id' ]
+        )->where(
+            'product_id = ?',
+            $productId
+        )->where(
+            'store_id = ?',
+            $storeId
+        );
+
+        $productYotpoId = $connection->fetchOne($productYotpoIdQuery, 'yotpo_id');
+        return $productYotpoId;
+    }
+
+    /**
+     * @param array $productsIds
+     * @return array<string>
+     */
+    public function getYotpoIdsFromProductsSyncTableByProductIds(array $productsIds)
+    {
+        $storeId = $this->coreConfig->getStoreId();
+        $connection = $this->resourceConnection->getConnection();
+        $productsYotpoIdsQuery = $connection->select(
+        )->from(
+            [ $this->resourceConnection->getTableName($this::YOTPO_PRODUCT_SYNC_TABLE_NAME) ],
+            [ 'product_id' , 'yotpo_id' ]
+        )->where(
+            'product_id IN (?)',
+            $productsIds
+        )->where(
+            'store_id = ?',
+            $storeId
+        );
+
+        $productsSyncData = $connection->fetchAssoc($productsYotpoIdsQuery, 'product_id');
+
+        $productIdsToYotpoIdsMap = [];
+        foreach ($productsSyncData as $productId => $productSyncRecord) {
+            $productIdsToYotpoIdsMap[$productId] = $productSyncRecord['yotpo_id'];
+        }
+
+        return $productIdsToYotpoIdsMap;
     }
 
     /**

--- a/Model/Sync/Category/Processor/Main.php
+++ b/Model/Sync/Category/Processor/Main.php
@@ -388,7 +388,7 @@ class Main extends AbstractJobs
      * @param DataObject|null $response
      * @return int|string|null
      */
-    public function getYotpoIdFromResponse($response)
+    public function getYotpoIdFromCreateCollectionResponse($response)
     {
         if (!$response) {
             return 0;

--- a/Model/Sync/Category/Processor/Main.php
+++ b/Model/Sync/Category/Processor/Main.php
@@ -23,6 +23,8 @@ use Magento\Store\Model\StoreManagerInterface;
  */
 class Main extends AbstractJobs
 {
+    const YOTPO_CATEGORY_SYNC_TABLE_NAME = 'yotpo_category_sync';
+
     /**
      * @var CategoryCollectionFactory
      */
@@ -439,5 +441,59 @@ class Main extends AbstractJobs
             ]
         );
         return $collection;
+    }
+
+    /**
+     * @param string $categoryId
+     * @return string
+     */
+    public function getYotpoIdFromCategoriesSyncTableByCategoryId($categoryId)
+    {
+        $storeId = $this->config->getStoreId();
+        $connection = $this->resourceConnection->getConnection();
+        $categoryYotpoIdQuery = $connection->select(
+        )->from(
+            [ $this->resourceConnection->getTableName($this::YOTPO_CATEGORY_SYNC_TABLE_NAME) ],
+            ['yotpo_id']
+        )->where(
+            'category_id = ?',
+            $categoryId
+        )->where(
+            'store_id = ?',
+            $storeId
+        );
+
+        $categoryYotpoId = $connection->fetchOne($categoryYotpoIdQuery, 'yotpo_id');
+        return $categoryYotpoId;
+    }
+
+    /**
+     * @param array $categoryIds
+     * @return array<string>
+     */
+    public function getYotpoIdsFromCategoriesSyncTableByCategoryIds(array $categoryIds)
+    {
+        $storeId = $this->config->getStoreId();
+        $connection = $this->resourceConnection->getConnection();
+        $categoryYotpoIdsQuery = $connection->select(
+        )->from(
+            [ $this->resourceConnection->getTableName($this::YOTPO_CATEGORY_SYNC_TABLE_NAME) ],
+            [ 'category_id', 'yotpo_id' ]
+        )->where(
+            'category_id IN (?)',
+            $categoryIds
+        )->where(
+            'store_id = ?',
+            $storeId
+        );
+
+        $categoriesSyncData = $connection->fetchAssoc($categoryYotpoIdsQuery, 'category_id');
+
+        $categoryIdsToYotpoIdsMap = [];
+        foreach ($categoriesSyncData as $categoryId => $categorySyncRecord) {
+            $categoryIdsToYotpoIdsMap[$categoryId] = $categorySyncRecord['yotpo_id'];
+        }
+
+        return $categoryIdsToYotpoIdsMap;
     }
 }

--- a/Model/Sync/Category/Processor/Main.php
+++ b/Model/Sync/Category/Processor/Main.php
@@ -230,6 +230,9 @@ class Main extends AbstractJobs
             $existingCollection = $this->getExistingCollectionIds([$categoryId]);
             if (!$existingCollection) {
                 $response = $this->syncAsNewCollection($category);
+                if ($this->config->isResponseIndicatesSuccess($response)) {
+                    $this->updateCategoryProductsForCollectionsProductsSync($category);
+                }
             } else {
                 $yotpoId = array_key_exists($categoryId, $existingCollection) ?
                     $existingCollection[$categoryId] : 0;

--- a/Model/Sync/Category/Processor/Main.php
+++ b/Model/Sync/Category/Processor/Main.php
@@ -219,6 +219,7 @@ class Main extends AbstractJobs
         if (!$yotpoId) {
             return;
         }
+
         $collectionData = $this->data->prepareData($category);
         $collectionData['entityLog'] = 'catalog';
         $url = $this->config->getEndpoint('collections_update', ['{yotpo_collection_id}'], [$yotpoId]);
@@ -230,9 +231,6 @@ class Main extends AbstractJobs
             $existingCollection = $this->getExistingCollectionIds([$categoryId]);
             if (!$existingCollection) {
                 $response = $this->syncAsNewCollection($category);
-                if ($this->config->isResponseIndicatesSuccess($response)) {
-                    $this->updateCategoryProductsForCollectionsProductsSync($category);
-                }
             } else {
                 $yotpoId = array_key_exists($categoryId, $existingCollection) ?
                     $existingCollection[$categoryId] : 0;
@@ -241,9 +239,11 @@ class Main extends AbstractJobs
                 }
             }
         }
+
         if ($yotpoId) {
             $response->setData('yotpo_id', $yotpoId);
         }
+
         return $response;
     }
 

--- a/Model/Sync/Category/Processor/Main.php
+++ b/Model/Sync/Category/Processor/Main.php
@@ -94,12 +94,12 @@ class Main extends AbstractJobs
         StoreManagerInterface $storeManager,
         CollectionsProductsService $collectionsProductsService
     ) {
-        $this->config   =   $config;
-        $this->data   =   $data;
-        $this->yotpoCoreApiSync             =   $yotpoCoreApiSync;
-        $this->categoryCollectionFactory    =   $categoryCollectionFactory;
-        $this->yotpoCoreCatalogLogger       =   $yotpoCoreCatalogLogger;
-        $this->entityIdFieldValue           =   $this->config->getEavRowIdFieldName();
+        $this->config = $config;
+        $this->data = $data;
+        $this->yotpoCoreApiSync = $yotpoCoreApiSync;
+        $this->categoryCollectionFactory = $categoryCollectionFactory;
+        $this->yotpoCoreCatalogLogger = $yotpoCoreCatalogLogger;
+        $this->entityIdFieldValue = $this->config->getEavRowIdFieldName();
         $this->storeManager = $storeManager;
         $this->collectionsProductsService = $collectionsProductsService;
         parent::__construct($appEmulation, $resourceConnection);
@@ -115,19 +115,19 @@ class Main extends AbstractJobs
         if (!$magentoCategories) {
             return [];
         }
-        $return     =   [];
-        $connection =   $this->resourceConnection->getConnection();
-        $storeId    =   $this->config->getStoreId();
-        $table      =   $this->resourceConnection->getTableName('yotpo_category_sync');
-        $categories =   $connection->select()
+        $return = [];
+        $connection = $this->resourceConnection->getConnection();
+        $storeId = $this->config->getStoreId();
+        $table = $this->resourceConnection->getTableName('yotpo_category_sync');
+        $categories = $connection->select()
             ->from($table)
             ->where('category_id IN(?) ', $magentoCategories)
             ->where('store_id=(?)', $storeId)
             ->where('yotpo_id > 0');
 
-        $categories =   $connection->fetchAssoc($categories, []);
+        $categories = $connection->fetchAssoc($categories, []);
         foreach ($categories as $cat) {
-            $return[$cat['category_id']]  =   $cat;
+            $return[$cat['category_id']] = $cat;
         }
         return $return;
     }
@@ -144,24 +144,24 @@ class Main extends AbstractJobs
             return [];
         }
         $yotpoCollections = [];
-        $categoryIds    =   array_chunk($categoryIds, 100);
+        $categoryIds = array_chunk($categoryIds, 100);
         foreach ($categoryIds as $chunk) {
-            $url                =   $this->config->getEndpoint('collections');
-            $data               =   ['external_ids' => implode(',', $chunk)];
-            $data['entityLog']  =   'catalog';
-            $response           =   $this->yotpoCoreApiSync->sync(Request::HTTP_METHOD_GET, $url, $data);
-            $response           =   $response->getData('response');
+            $url = $this->config->getEndpoint('collections');
+            $data = ['external_ids' => implode(',', $chunk)];
+            $data['entityLog'] = 'catalog';
+            $response = $this->yotpoCoreApiSync->sync(Request::HTTP_METHOD_GET, $url, $data);
+            $response = $response->getData('response');
             if (!$response) {
                 continue;
             }
-            $collections    =   is_array($response) && isset($response['collections']) ? $response['collections'] : [];
+            $collections = is_array($response) && isset($response['collections']) ? $response['collections'] : [];
             $count = count($collections);
-            for ($i=0; $i<$count; $i++) {
+            for ($i = 0; $i < $count; $i++) {
                 if (is_array($collections[$i])
                     && isset($collections[$i]['external_id'])
                     && isset($collections[$i]['yotpo_id'])
                 ) {
-                    $yotpoCollections[$collections[$i]['external_id']]  =   $collections[$i]['yotpo_id'];
+                    $yotpoCollections[$collections[$i]['external_id']] = $collections[$i]['yotpo_id'];
                 }
             }
         }
@@ -180,24 +180,24 @@ class Main extends AbstractJobs
             return [];
         }
         $yotpoCollections = [];
-        $categoryIds    =   array_chunk($categoryIds, 100);
+        $categoryIds = array_chunk($categoryIds, 100);
         foreach ($categoryIds as $chunk) {
-            $url                =   $this->config->getEndpoint('collections');
-            $data               =   ['external_ids' => implode(',', $chunk)];
-            $data['entityLog']  =   'catalog';
-            $response           =   $this->yotpoCoreApiSync->sync(Request::HTTP_METHOD_GET, $url, $data);
-            $response           =   $response->getData('response');
+            $url = $this->config->getEndpoint('collections');
+            $data = ['external_ids' => implode(',', $chunk)];
+            $data['entityLog'] = 'catalog';
+            $response = $this->yotpoCoreApiSync->sync(Request::HTTP_METHOD_GET, $url, $data);
+            $response = $response->getData('response');
             if (!$response) {
                 continue;
             }
-            $collections    =   is_array($response) && isset($response['collections']) ? $response['collections'] : [];
+            $collections = is_array($response) && isset($response['collections']) ? $response['collections'] : [];
             $count = count($collections);
-            for ($i=0; $i<$count; $i++) {
+            for ($i = 0; $i < $count; $i++) {
                 if (is_array($collections[$i])
                     && isset($collections[$i]['external_id'])
                     && isset($collections[$i]['yotpo_id'])
                 ) {
-                    $yotpoCollections[$collections[$i]['external_id']]  =   [
+                    $yotpoCollections[$collections[$i]['external_id']] = [
                         'yotpo_id' => $collections[$i]['yotpo_id'],
                         'name' => $collections[$i]['name']
                     ];
@@ -217,12 +217,12 @@ class Main extends AbstractJobs
     public function syncExistingCollection(Category $category, int $yotpoId)
     {
         if (!$yotpoId) {
-            return ;
+            return;
         }
-        $collectionData                 =   $this->data->prepareData($category);
-        $collectionData['entityLog']    = 'catalog';
-        $url    =   $this->config->getEndpoint('collections_update', ['{yotpo_collection_id}'], [$yotpoId]);
-        $response =  $this->yotpoCoreApiSync->sync(\Zend_Http_Client::PATCH, $url, $collectionData);
+        $collectionData = $this->data->prepareData($category);
+        $collectionData['entityLog'] = 'catalog';
+        $url = $this->config->getEndpoint('collections_update', ['{yotpo_collection_id}'], [$yotpoId]);
+        $response = $this->yotpoCoreApiSync->sync(\Zend_Http_Client::PATCH, $url, $collectionData);
         $categoryId = $category->getId();
         $storeId = $category->getStoreId();
         if ($this->isImmediateRetry($response, $this->entity, $categoryId, $storeId)) {
@@ -232,7 +232,7 @@ class Main extends AbstractJobs
                 $response = $this->syncAsNewCollection($category);
             } else {
                 $yotpoId = array_key_exists($categoryId, $existingCollection) ?
-                    $existingCollection[$categoryId]  : 0;
+                    $existingCollection[$categoryId] : 0;
                 if ($yotpoId) {
                     $response = $this->syncExistingCollection($category, $yotpoId);
                 }
@@ -254,16 +254,16 @@ class Main extends AbstractJobs
             return [];
         }
         $data = [
-            'response_code' =>  $response->getData('status'),
+            'response_code' => $response->getData('status'),
         ];
-        $responseData   =   $response->getData('response');
-        $data['yotpo_id']   =   null;
+        $responseData = $response->getData('response');
+        $data['yotpo_id'] = null;
         if ($response->getData('yotpo_id')) {
-            $data['yotpo_id']   =   $response->getData('yotpo_id');
+            $data['yotpo_id'] = $response->getData('yotpo_id');
         } elseif ($responseData && is_array($responseData) &&
             array_key_exists('collection', $responseData) && $responseData['collection']
         ) {
-            $data['yotpo_id']   =   $responseData['collection']['yotpo_id'];
+            $data['yotpo_id'] = $responseData['collection']['yotpo_id'];
         }
         return $data;
     }
@@ -276,11 +276,11 @@ class Main extends AbstractJobs
     {
         $finalData = [];
         $finalData[] = [
-            'category_id'        =>  $data['category_id'],
-            'synced_to_yotpo'    =>  $data['synced_to_yotpo'],
-            'response_code'      =>  $data['response_code'],
-            'yotpo_id'           =>  $data['yotpo_id'],
-            'store_id'           =>  $data['store_id'],
+            'category_id' => $data['category_id'],
+            'synced_to_yotpo' => $data['synced_to_yotpo'],
+            'response_code' => $data['response_code'],
+            'yotpo_id' => $data['yotpo_id'],
+            'store_id' => $data['store_id'],
         ];
         $this->insertOnDuplicate('yotpo_category_sync', $finalData);
     }
@@ -303,10 +303,10 @@ class Main extends AbstractJobs
     public function unAssignProductFromCollection(int $yotpoCollectionId, int $productId): bool
     {
 
-        $url    =   $this->config->getEndpoint('collections_product', ['{yotpo_collection_id}'], [$yotpoCollectionId]);
-        $data               =   $this->data->prepareProductData($productId);
-        $data['entityLog']  =   'catalog';
-        $response           =   $this->yotpoCoreApiSync->sync(Request::HTTP_METHOD_DELETE, $url, $data);
+        $url = $this->config->getEndpoint('collections_product', ['{yotpo_collection_id}'], [$yotpoCollectionId]);
+        $data = $this->data->prepareProductData($productId);
+        $data['entityLog'] = 'catalog';
+        $response = $this->yotpoCoreApiSync->sync(Request::HTTP_METHOD_DELETE, $url, $data);
         $responseCode = $response && $response->getData('status') ? $response->getData('status') : null;
         return ($response && $response->getData('is_success')) || $responseCode == '404';
     }
@@ -320,23 +320,23 @@ class Main extends AbstractJobs
         if (!$categories) {
             return [];
         }
-        $magentoCategories  =   [];
-        $categoryPathIds    =   [];
-        $categoriesByPath   =   [];
+        $magentoCategories = [];
+        $categoryPathIds = [];
+        $categoriesByPath = [];
         foreach ($categories as $category) {
-            $path   =   explode('/', $category->getPath());
+            $path = explode('/', $category->getPath());
             array_shift($path);
             $categoryPathIds[] = $path;
-            $magentoCategories[$category->getId()]  =   $category;
+            $magentoCategories[$category->getId()] = $category;
         }
         $categoryPathIds = array_merge(...$categoryPathIds);
-        $categoryPathIds    =   array_filter(array_unique($categoryPathIds));
-        $existingInMagentoCategories    =   array_intersect($categoryPathIds, array_keys($magentoCategories));
+        $categoryPathIds = array_filter(array_unique($categoryPathIds));
+        $existingInMagentoCategories = array_intersect($categoryPathIds, array_keys($magentoCategories));
         foreach ($existingInMagentoCategories as $exMageCatId) {
-            $categoriesByPath[$exMageCatId] =   $magentoCategories[$exMageCatId];
+            $categoriesByPath[$exMageCatId] = $magentoCategories[$exMageCatId];
         }
-        $nonExistingInMagentoCategories    =   array_diff($categoryPathIds, array_keys($magentoCategories));
-        $catCollectionOth   =   $this->categoryCollectionFactory->create();
+        $nonExistingInMagentoCategories = array_diff($categoryPathIds, array_keys($magentoCategories));
+        $catCollectionOth = $this->categoryCollectionFactory->create();
         $catCollectionOth->addNameToResult();
         $catCollectionOth->addFieldToFilter(
             'entity_id',
@@ -344,7 +344,7 @@ class Main extends AbstractJobs
         );
 
         foreach ($catCollectionOth->getItems() as $collectionOthCatItem) {
-            $categoriesByPath[$collectionOthCatItem->getId()] =   $collectionOthCatItem;
+            $categoriesByPath[$collectionOthCatItem->getId()] = $collectionOthCatItem;
         }
 
         return $categoriesByPath;
@@ -357,7 +357,7 @@ class Main extends AbstractJobs
      */
     public function getNameWithPath(Category $singleCategory, array $categories)
     {
-        $singleCatPath   =   explode('/', (string) $singleCategory->getPath());
+        $singleCatPath = explode('/', (string)$singleCategory->getPath());
         array_shift($singleCatPath);
         if (!$singleCatPath) {
             return;
@@ -365,7 +365,7 @@ class Main extends AbstractJobs
         $singleCatNames = [];
 
         foreach ($singleCatPath as $singleCatId) {
-            $singleCatNames[]   =   $categories[$singleCatId]->getName();
+            $singleCatNames[] = $categories[$singleCatId]->getName();
         }
 
         return implode('/', $singleCatNames);
@@ -378,9 +378,9 @@ class Main extends AbstractJobs
      */
     public function syncAsNewCollection(Category $category)
     {
-        $collectionData                 =   $this->data->prepareData($category);
-        $collectionData['entityLog']    = 'catalog';
-        $url                            =   $this->config->getEndpoint('collections');
+        $collectionData = $this->data->prepareData($category);
+        $collectionData['entityLog'] = 'catalog';
+        $url = $this->config->getEndpoint('collections');
         return $this->yotpoCoreApiSync->sync(Request::HTTP_METHOD_POST, $url, $collectionData);
     }
 
@@ -412,13 +412,13 @@ class Main extends AbstractJobs
     public function updateCategoryAttribute($categoryRowId)
     {
         $dataToInsertOrUpdate = [];
-        $data   =   [
-            'attribute_id'  =>  $this->data->getAttributeId('synced_to_yotpo_collection'),
-            'store_id'      =>  $this->config->getStoreid(),
+        $data = [
+            'attribute_id' => $this->data->getAttributeId('synced_to_yotpo_collection'),
+            'store_id' => $this->config->getStoreid(),
             $this->entityIdFieldValue => $categoryRowId,
-            'value'         =>  1
+            'value' => 1
         ];
-        $dataToInsertOrUpdate[] =   $data;
+        $dataToInsertOrUpdate[] = $data;
         $this->insertOnDuplicate('catalog_category_entity_int', $dataToInsertOrUpdate);
     }
 
@@ -438,7 +438,7 @@ class Main extends AbstractJobs
      */
     public function getStoreCategoryCollection()
     {
-        /** @var \Magento\Store\Model\Store $currentStore**/
+        /** @var \Magento\Store\Model\Store $currentStore **/
         $currentStore = $this->storeManager->getStore();
         $rootCategoryId = $currentStore->getRootCategoryId();
         $collection = $this->categoryCollectionFactory->create();
@@ -460,8 +460,7 @@ class Main extends AbstractJobs
     {
         $storeId = $this->config->getStoreId();
         $connection = $this->resourceConnection->getConnection();
-        $categoryYotpoIdQuery = $connection->select(
-        )->from(
+        $categoryYotpoIdQuery = $connection->select()->from(
             [ $this->resourceConnection->getTableName($this::YOTPO_CATEGORY_SYNC_TABLE_NAME) ],
             ['yotpo_id']
         )->where(

--- a/Model/Sync/Category/Processor/Main.php
+++ b/Model/Sync/Category/Processor/Main.php
@@ -300,21 +300,6 @@ class Main extends AbstractJobs
     }
 
     /**
-     * @param int $yotpoCollectionId
-     * @param int $productId
-     */
-    public function unAssignProductFromCollection(int $yotpoCollectionId, int $productId): bool
-    {
-
-        $url = $this->config->getEndpoint('collections_product', ['{yotpo_collection_id}'], [$yotpoCollectionId]);
-        $data = $this->data->prepareProductData($productId);
-        $data['entityLog'] = 'catalog';
-        $response = $this->yotpoCoreApiSync->sync(Request::HTTP_METHOD_DELETE, $url, $data);
-        $responseCode = $response && $response->getData('status') ? $response->getData('status') : null;
-        return ($response && $response->getData('is_success')) || $responseCode == '404';
-    }
-
-    /**
      * @param array<mixed> $categories
      * @return array<mixed>
      */
@@ -385,26 +370,6 @@ class Main extends AbstractJobs
         $collectionData['entityLog'] = 'catalog';
         $url = $this->config->getEndpoint('collections');
         return $this->yotpoCoreApiSync->sync(Request::HTTP_METHOD_POST, $url, $collectionData);
-    }
-
-    /**
-     * @param DataObject|null $response
-     * @return int|string|null
-     */
-    public function getYotpoIdFromCreateCollectionResponse($response)
-    {
-        if (!$response) {
-            return 0;
-        }
-        $responseData   =   $response->getData('response');
-        $yotpoId = null;
-        if ($response->getData('yotpo_id')) {
-            $yotpoId   =   $response->getData('yotpo_id');
-        } elseif ($responseData && is_array($responseData) && isset($responseData['collection'])) {
-            $yotpoId   =   is_array($responseData['collection']) && isset($responseData['collection']['yotpo_id']) ?
-                $responseData['collection']['yotpo_id'] : 0;
-        }
-        return $yotpoId;
     }
 
     /**

--- a/Model/Sync/Category/Processor/Main.php
+++ b/Model/Sync/Category/Processor/Main.php
@@ -508,9 +508,10 @@ class Main extends AbstractJobs
 
     /**
      * @param Category $category
+     * @param boolean $isDeletedInMagento
      * @return void
      */
-    public function updateCategoryProductsForCollectionsProductsSync($category)
+    public function updateCategoryProductsForCollectionsProductsSync($category, $isDeletedInMagento = false)
     {
         $categoryId = $category->getId();
         $storeIdsSuccessfullySyncedWithCategory = $this->getStoresSuccessfullySyncedWithCategory($categoryId);
@@ -523,7 +524,7 @@ class Main extends AbstractJobs
                         $categoryProductsIds[] = $categoryProduct->getId();
                     }
 
-                    $this->collectionsProductsService->assignCategoryProductsForCollectionsProductsSync($categoryProductsIds, $storeId, $categoryId);
+                    $this->collectionsProductsService->assignCategoryProductsForCollectionsProductsSync($categoryProductsIds, $storeId, $categoryId, $isDeletedInMagento);
                 }
             }
         }

--- a/Model/Sync/Category/Processor/Main.php
+++ b/Model/Sync/Category/Processor/Main.php
@@ -214,7 +214,7 @@ class Main extends AbstractJobs
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function syncExistingCollection(Category $category, int $yotpoId)
+    public function syncExistingOrNewCollection(Category $category, int $yotpoId)
     {
         if (!$yotpoId) {
             return;
@@ -234,7 +234,7 @@ class Main extends AbstractJobs
                 $yotpoId = array_key_exists($categoryId, $existingCollection) ?
                     $existingCollection[$categoryId] : 0;
                 if ($yotpoId) {
-                    $response = $this->syncExistingCollection($category, $yotpoId);
+                    $response = $this->syncExistingOrNewCollection($category, $yotpoId);
                 }
             }
         }

--- a/Model/Sync/Category/Processor/ProcessByCategory.php
+++ b/Model/Sync/Category/Processor/ProcessByCategory.php
@@ -138,9 +138,12 @@ class ProcessByCategory extends Main
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function processEntity($retryCategoryIds = [])
+    public function processEntity($retryCategoryIds = [], $storeId = null)
     {
-        $storeId = $this->config->getStoreId();
+        if (!$storeId) {
+            $storeId = $this->config->getStoreId();
+        }
+
         $currentTime = date('Y-m-d H:i:s');
         $batchSize = $this->config->getConfig('product_sync_limit');
         $existColls = [];

--- a/Model/Sync/Category/Processor/ProcessByCategory.php
+++ b/Model/Sync/Category/Processor/ProcessByCategory.php
@@ -200,7 +200,7 @@ class ProcessByCategory extends Main
                 $yotpoSyncedCategories[$categoryId]['yotpo_id'],
                 $this->isCommandLineSync
             )) {
-                $response = $this->syncExistingCollection(
+                $response = $this->syncExistingOrNewCollection(
                     $magentoCategory,
                     $yotpoSyncedCategories[$categoryId]['yotpo_id']
                 );
@@ -209,7 +209,7 @@ class ProcessByCategory extends Main
                 $this->updateCategoryAttribute($categoryIdToUpdate);
             }
             if (isset($existingCollections[$categoryId])) {
-                $response = $this->syncExistingCollection(
+                $response = $this->syncExistingOrNewCollection(
                     $magentoCategory,
                     $existingCollections[$categoryId]
                 );

--- a/Model/Sync/Category/Processor/ProcessByCategory.php
+++ b/Model/Sync/Category/Processor/ProcessByCategory.php
@@ -140,6 +140,7 @@ class ProcessByCategory extends Main
      */
     public function processEntity($retryCategoryIds = [])
     {
+        $storeId = $this->config->getStoreId();
         $currentTime = date('Y-m-d H:i:s');
         $batchSize = $this->config->getConfig('product_sync_limit');
         $existColls = [];
@@ -217,7 +218,7 @@ class ProcessByCategory extends Main
                 ) {
                     $yotpoTableData['yotpo_id'] = $yotpoSyncedCategories[$magentoCategory->getId()]['yotpo_id'];
                 }
-                $yotpoTableData['store_id']         =   $this->config->getStoreId();
+                $yotpoTableData['store_id']         =   $storeId;
                 $yotpoTableData['category_id']      =   $magentoCategory->getId();
                 $yotpoTableData['synced_to_yotpo']  =   $currentTime;
                 $this->insertOrUpdateYotpoTableData($yotpoTableData);
@@ -239,7 +240,7 @@ class ProcessByCategory extends Main
             $data = [
                 'response_code' => '201',
                 'yotpo_id' => $yotpoId,
-                'store_id' => $this->config->getStoreId(),
+                'store_id' => $storeId,
                 'category_id' => $mageCatId,
                 'synced_to_yotpo' => $currentTime
             ];
@@ -254,8 +255,8 @@ class ProcessByCategory extends Main
         $this->yotpoCoreCatalogLogger->info(
             sprintf(
                 'Category Sync - sync completed - Magento Store ID: %s, Name: %s',
-                $this->config->getStoreId(),
-                $this->config->getStoreName($this->config->getStoreId())
+                $storeId,
+                $this->config->getStoreName($storeId)
             )
         );
     }

--- a/Model/Sync/Category/Processor/ProcessByCategory.php
+++ b/Model/Sync/Category/Processor/ProcessByCategory.php
@@ -186,7 +186,9 @@ class ProcessByCategory extends Main
             /** @var Category $magentoCategory */
             $magentoCategory->setData('nameWithPath', $this->getNameWithPath($magentoCategory, $categoriesByPath));
             $categoryId = $magentoCategory->getId();
+            $currentCategoryYotpoId = $yotpoSyncedCategories[$categoryId]['yotpo_id'] ?? 0;
             $response = null;
+
             if (!$this->isCategoryWasEverSynced($yotpoSyncedCategories, $existingCollections, $magentoCategory)
                 || $this->isSyncedCategoryMissingYotpoId($yotpoSyncedCategories, $magentoCategory)
             ) {
@@ -197,12 +199,12 @@ class ProcessByCategory extends Main
                 }
             } elseif ($this->canResync(
                 $yotpoSyncedCategories[$categoryId],
-                $yotpoSyncedCategories[$categoryId]['yotpo_id'],
+                $currentCategoryYotpoId,
                 $this->isCommandLineSync
             )) {
                 $response = $this->syncExistingOrNewCollection(
                     $magentoCategory,
-                    $yotpoSyncedCategories[$categoryId]['yotpo_id']
+                    $currentCategoryYotpoId
                 );
             } else {
                 $categoryIdToUpdate = $magentoCategory->getRowId() ?: $categoryId;
@@ -223,12 +225,21 @@ class ProcessByCategory extends Main
             }
             $yotpoTableData = $response ? $this->prepareYotpoTableData($response) : [];
             if ($yotpoTableData) {
-                if (array_key_exists('yotpo_id', $yotpoTableData) &&
-                    !$yotpoTableData['yotpo_id']
+                if (array_key_exists('yotpo_id', $yotpoTableData)
+                    && !$yotpoTableData['yotpo_id']
                     && array_key_exists($categoryId, $yotpoSyncedCategories)
                 ) {
-                    $yotpoTableData['yotpo_id'] = $yotpoSyncedCategories[$categoryId]['yotpo_id'];
+                    $yotpoTableData['yotpo_id'] = $currentCategoryYotpoId;
                 }
+
+                if ($currentCategoryYotpoId
+                    && array_key_exists('yotpo_id', $yotpoTableData)
+                    && $yotpoTableData['yotpo_id']
+                    && $currentCategoryYotpoId != $yotpoTableData['yotpo_id']
+                ) {
+                    $this->updateCategoryProductsForCollectionsProductsSync($magentoCategory);
+                }
+
                 $yotpoTableData['store_id'] = $storeId;
                 $yotpoTableData['category_id'] = $categoryId;
                 $yotpoTableData['synced_to_yotpo'] = $currentTime;

--- a/Model/Sync/Category/Processor/ProcessByCategory.php
+++ b/Model/Sync/Category/Processor/ProcessByCategory.php
@@ -269,7 +269,6 @@ class ProcessByCategory extends Main
     {
         $this->yotpoCoreCatalogLogger->info('Category Sync - delete categories start');
         $categoriesToDelete = $this->getCollectionsToDelete();
-        $catToUpdateAsDel = [];
         foreach ($categoriesToDelete as $cat) {
             $products = $this->getProductsUnderCategory($cat['yotpo_id']);
             $this->yotpoCoreCatalogLogger->info(

--- a/Model/Sync/Category/Processor/ProcessByCategory.php
+++ b/Model/Sync/Category/Processor/ProcessByCategory.php
@@ -269,18 +269,18 @@ class ProcessByCategory extends Main
     {
         $this->yotpoCoreCatalogLogger->info('Category Sync - delete categories start');
         $categoriesToDelete = $this->getCollectionsToDelete();
-        foreach ($categoriesToDelete as $cat) {
-            $products = $this->getProductsUnderCategory($cat['yotpo_id']);
+        foreach ($categoriesToDelete as $category) {
+            $products = $this->getProductsUnderCategory($category['yotpo_id']);
             $this->yotpoCoreCatalogLogger->info(
-                sprintf('Category Sync - delete categories - Category ID - %s', $cat['category_id'])
+                sprintf('Category Sync - delete categories - Category ID - %s', $category['category_id'])
             );
             foreach ($products as $product) {
-                $success = $this->unAssignProductFromCollection($cat['yotpo_id'], $product['external_id']);
+                $success = $this->unAssignProductFromCollection($category['yotpo_id'], $product['external_id']);
                 if ($success) {
-                    $this->updateYotpoTblForDeletedCategories($cat['category_id']);
+                    $this->updateYotpoTblForDeletedCategories($category['category_id']);
                     $this->yotpoCoreCatalogLogger->info(
                         'Category Sync - Delete categories - Finished - Update Category ID -
-                    ' . $cat['category_id']
+                    ' . $category['category_id']
                     );
                 }
             }

--- a/Model/Sync/Category/Processor/ProcessByCategory.php
+++ b/Model/Sync/Category/Processor/ProcessByCategory.php
@@ -77,7 +77,8 @@ class ProcessByCategory extends Main
             $yotpoCoreApiSync,
             $categoryCollectionFactory,
             $yotpoCoreCatalogLogger,
-            $storeManager
+            $storeManager,
+            $collectionsProductsService
         );
         $this->categoryHelper = $categoryHelper;
         $this->categorySyncRepositoryInterface = $categorySyncRepositoryInterface;
@@ -190,6 +191,10 @@ class ProcessByCategory extends Main
                 || $this->isSyncedCategoryMissingYotpoId($yotpoSyncedCategories, $magentoCategory)
             ) {
                 $response = $this->syncAsNewCollection($magentoCategory);
+                $isCategorySyncedSuccessfully = $this->config->isResponseIndicatesSuccess($response);
+                if ($isCategorySyncedSuccessfully) {
+                    $this->updateCategoryProductsForCollectionsProductsSync($magentoCategory);
+                }
             } elseif ($this->canResync(
                 $yotpoSyncedCategories[$categoryId],
                 $yotpoSyncedCategories[$categoryId]['yotpo_id'],
@@ -257,6 +262,7 @@ class ProcessByCategory extends Main
                 $this->updateCategoryAttribute($categoryIdToUpdate);
             }
         }
+
         $this->deleteCollections();
         $this->yotpoCoreCatalogLogger->info(
             sprintf(

--- a/Model/Sync/Category/Processor/ProcessByCategory.php
+++ b/Model/Sync/Category/Processor/ProcessByCategory.php
@@ -116,7 +116,7 @@ class ProcessByCategory extends Main
                     )
                 );
                 $retryCategoryIds = $retryCategories[$storeId] ?? $retryCategories;
-                $this->processEntity($retryCategoryIds);
+                $this->processEntities($retryCategoryIds);
                 $this->stopEnvironmentEmulation();
                 $this->yotpoCoreCatalogLogger->info(
                     sprintf(
@@ -147,7 +147,7 @@ class ProcessByCategory extends Main
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function processEntity($retryCategoryIds = [], $storeId = null)
+    public function processEntities($retryCategoryIds = [], $storeId = null)
     {
         if (!$storeId) {
             $storeId = $this->config->getStoreId();

--- a/Model/Sync/Category/Processor/ProcessByCategory.php
+++ b/Model/Sync/Category/Processor/ProcessByCategory.php
@@ -185,37 +185,30 @@ class ProcessByCategory extends Main
             /** @var Category $magentoCategory */
             $magentoCategory->setData('nameWithPath', $this->getNameWithPath($magentoCategory, $categoriesByPath));
             $response = null;
-            if (!isset($yotpoSyncedCategories[$magentoCategory->getId()]) &&
-                !isset($existingCollections[$magentoCategory->getId()])
+            if (!$this->isCategoryWasEverSynced($yotpoSyncedCategories, $existingCollections, $magentoCategory)
+                || $this->isSyncedCategoryMissingYotpoId($yotpoSyncedCategories, $magentoCategory)
             ) {
                 $response = $this->syncAsNewCollection($magentoCategory);
+            } elseif ($this->canResync(
+                $yotpoSyncedCategories[$magentoCategory->getId()],
+                $yotpoSyncedCategories[$magentoCategory->getId()]['yotpo_id'],
+                $this->isCommandLineSync
+            )) {
+                $response = $this->syncExistingCollection(
+                    $magentoCategory,
+                    $yotpoSyncedCategories[$magentoCategory->getId()]['yotpo_id']
+                );
             } else {
-                if (isset($yotpoSyncedCategories[$magentoCategory->getId()])) {
-                    if ($yotpoSyncedCategories[$magentoCategory->getId()]['yotpo_id']) {
-                        if ($this->canResync(
-                            $yotpoSyncedCategories[$magentoCategory->getId()],
-                            $yotpoSyncedCategories[$magentoCategory->getId()]['yotpo_id'],
-                            $this->isCommandLineSync
-                        )) {
-                            $response = $this->syncExistingCollection(
-                                $magentoCategory,
-                                $yotpoSyncedCategories[$magentoCategory->getId()]['yotpo_id']
-                            );
-                        } else {
-                            $categoryIdToUpdate = $magentoCategory->getRowId() ?: $magentoCategory->getId();
-                            $this->updateCategoryAttribute($categoryIdToUpdate);
-                        }
-                    } else {
-                        $response = $this->syncAsNewCollection($magentoCategory);
-                    }
-                } elseif (isset($existingCollections[$magentoCategory->getId()])) {
-                    $response = $this->syncExistingCollection(
-                        $magentoCategory,
-                        $existingCollections[$magentoCategory->getId()]
-                    );
-                    if (!$response->getData('yotpo_id')) {
-                        $response->setData('yotpo_id', $existingCollections[$magentoCategory->getId()]);
-                    }
+                $categoryIdToUpdate = $magentoCategory->getRowId() ?: $magentoCategory->getId();
+                $this->updateCategoryAttribute($categoryIdToUpdate);
+            }
+            if (isset($existingCollections[$magentoCategory->getId()])) {
+                $response = $this->syncExistingCollection(
+                    $magentoCategory,
+                    $existingCollections[$magentoCategory->getId()]
+                );
+                if (!$response->getData('yotpo_id')) {
+                    $response->setData('yotpo_id', $existingCollections[$magentoCategory->getId()]);
                 }
             }
             if ($this->checkForCollectionExistsError($response)) {
@@ -395,5 +388,26 @@ class ProcessByCategory extends Main
             // phpcs:ignore
             echo 'No category data to process.' . PHP_EOL;
         }
+    }
+
+    /**
+     * @param array $yotpoSyncedCategories
+     * @param array $existingCollections
+     * @param Category $magentoCategory
+     * @return bool
+     */
+    private function isCategoryWasEverSynced(array $yotpoSyncedCategories, array $existingCollections, Category $magentoCategory)
+    {
+        return isset($yotpoSyncedCategories[$magentoCategory->getId()]) && isset($existingCollections[$magentoCategory->getId()]);
+    }
+
+    /**
+     * @param array $yotpoSyncedCategories
+     * @param Category $magentoCategory
+     * @return bool
+     */
+    private function isSyncedCategoryMissingYotpoId(array $yotpoSyncedCategories, Category $magentoCategory)
+    {
+        return isset($yotpoSyncedCategories[$magentoCategory->getId()]) && !$yotpoSyncedCategories[$magentoCategory->getId()]['yotpo_id'];
     }
 }

--- a/Model/Sync/Category/Processor/ProcessByCategory.php
+++ b/Model/Sync/Category/Processor/ProcessByCategory.php
@@ -275,17 +275,14 @@ class ProcessByCategory extends Main
             $this->yotpoCoreCatalogLogger->info(
                 sprintf('Category Sync - delete categories - Category ID - %s', $category['category_id'])
             );
+
             foreach ($products as $product) {
-                $success = $this->unAssignProductFromCollection($category['yotpo_id'], $product['external_id']);
-                if ($success) {
-                    $this->updateYotpoTblForDeletedCategories($category['category_id']);
-                    $this->yotpoCoreCatalogLogger->info(
-                        'Category Sync - Delete categories - Finished - Update Category ID -
-                    ' . $category['category_id']
-                    );
-                }
+                $this->unAssignProductFromCollection($category['yotpo_id'], $product['external_id']);
             }
+
+            $this->updateYotpoTblForDeletedCategories($category['category_id']);
         }
+
         $this->yotpoCoreCatalogLogger->info('Category Sync - delete categories complete');
     }
 

--- a/Model/Sync/Category/Processor/ProcessByProduct.php
+++ b/Model/Sync/Category/Processor/ProcessByProduct.php
@@ -363,8 +363,7 @@ class ProcessByProduct extends Main
                 return $yotpoIdToReturn;
             }
             if ($this->checkForCollectionExistsError($newCollectionResponse)) {
-                $existColls = [$categoryId];
-                $existingCollections = $this->getExistingCollection($existColls);
+                $existingCollections = $this->getExistingCollection([$categoryId]);
                 $yotpoIdToReturn = $this->updateIfNameIsDifferent($existingCollections, $categories, $categoryId);
                 if ($yotpoIdToReturn) {
                     $newCollections = [];

--- a/Model/Sync/Category/Processor/ProcessByProduct.php
+++ b/Model/Sync/Category/Processor/ProcessByProduct.php
@@ -209,7 +209,7 @@ class ProcessByProduct extends Main
         $yotpoTableData['synced_to_yotpo'] = $currentTime;
         if (!$existingCollection) {
             $response = $this->syncAsNewCollection($category);
-            $yotpoId = $this->getYotpoIdFromResponse($response);
+            $yotpoId = $this->getYotpoIdFromCreateCollectionResponse($response);
             $yotpoTableRespData = $response ? $this->prepareYotpoTableData($response) : [];
             if ($yotpoTableRespData && is_array($yotpoTableRespData)) {
                 $yotpoTableData = array_merge($yotpoTableData, $yotpoTableRespData);
@@ -375,7 +375,7 @@ class ProcessByProduct extends Main
                         ?: $categories[$categoryId]->getId();
                 }
             } else {
-                $yotpoIdToReturn = $this->getYotpoIdFromResponse($newCollectionResponse);
+                $yotpoIdToReturn = $this->getYotpoIdFromCreateCollectionResponse($newCollectionResponse);
                 $newCollections = [];
                 $newCollections[$categoryId] = [
                     'yotpo_id' => $yotpoIdToReturn,
@@ -413,7 +413,7 @@ class ProcessByProduct extends Main
                     $categories[$categoryId],
                     $existingProdCollYotpo[$categoryId]['yotpo_id']
                 );
-                $yotpoIdToReturn = $this->getYotpoIdFromResponse($response);
+                $yotpoIdToReturn = $this->getYotpoIdFromCreateCollectionResponse($response);
             } else {
                 $yotpoIdToReturn = $existingProdCollYotpo[$categoryId]['yotpo_id'];
             }

--- a/Model/Sync/Category/Processor/ProcessByProduct.php
+++ b/Model/Sync/Category/Processor/ProcessByProduct.php
@@ -354,15 +354,15 @@ class ProcessByProduct extends Main
             $categoryIdToUpdate = $categories[$categoryId]->getRowId()
                 ?: $categories[$categoryId]->getId();
         } else {
-            $createCollection = $this->yotpoCoreApiSync->sync(
+            $newCollectionResponse = $this->yotpoCoreApiSync->sync(
                 Request::HTTP_METHOD_POST,
                 $url,
                 $collectionData
             );
-            if (!$createCollection) {
+            if (!$newCollectionResponse) {
                 return $yotpoIdToReturn;
             }
-            if ($this->checkForCollectionExistsError($createCollection)) {
+            if ($this->checkForCollectionExistsError($newCollectionResponse)) {
                 $existColls = [$categoryId];
                 $existingCollections = $this->getExistingCollection($existColls);
                 $yotpoIdToReturn = $this->updateIfNameIsDifferent($existingCollections, $categories, $categoryId);
@@ -376,7 +376,7 @@ class ProcessByProduct extends Main
                         ?: $categories[$categoryId]->getId();
                 }
             } else {
-                $yotpoIdToReturn = $this->getYotpoIdFromResponse($createCollection);
+                $yotpoIdToReturn = $this->getYotpoIdFromResponse($newCollectionResponse);
                 $newCollections = [];
                 $newCollections[$categoryId] = [
                     'yotpo_id' => $yotpoIdToReturn,

--- a/Model/Sync/Category/Processor/ProcessByProduct.php
+++ b/Model/Sync/Category/Processor/ProcessByProduct.php
@@ -7,7 +7,6 @@ use Magento\Catalog\Model\Product;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Webapi\Rest\Request;
-use Yotpo\Core\Model\Config as YotpoCoreConfig;
 
 /**
  * Class ProcessByProduct - Process category sync
@@ -15,119 +14,33 @@ use Yotpo\Core\Model\Config as YotpoCoreConfig;
 class ProcessByProduct extends Main
 {
 
-    /**
-     * @var null
-     */
-    protected $collections = null;
-
-    /**
-     * @var string
-     */
-    protected $entity = 'product_category';
-
-    /**
-     * @var array <mixed>
-     */
-    protected $existingCollectionsInYotpo = [];
-
-    /**
-     * @param array<mixed> $products
-     * @return void
-     * @throws NoSuchEntityException|LocalizedException
-     */
-    public function process(array $products = [])
+    public function process(array $productItems)
     {
-        $this->yotpoCoreCatalogLogger->info('Category Sync - Process categories by product - START ', []);
-        $categories = $this->prepareCategories($products);
-        $existingCollections = $this->getYotpoSyncedCategories(array_keys($categories));
-        $newCollectionsToLog = [];
+        $this->yotpoCoreCatalogLogger->info('Category Sync - Process categories by product - START ');
 
-        foreach ($existingCollections as $catId => $cat) {
-            if (!$this->config->canResync($cat['response_code'], $cat['yotpo_id'])) {
-                $this->yotpoCoreCatalogLogger->info(
-                    'Category Sync - Process categories by product - Category can\'t be synced %1 , response_code - %1',
-                    [$catId, $cat['response_code']]
-                );
-                unset($categories[$catId]);
-            }
-        }
-        $categoriesByPath = $this->getCategoriesFromPathNames(array_values($categories));
-        $existingProductsToCollectionsMap = [];
-        $productIdsToCategoriesIdsMap = [];
-
-        foreach ($products as $yotpoProductId => $product) {
-            /** @var Product $product * */
-            $productIdsToCategoriesIdsMap[$product->getId()] = [];
-            $productCategories = $product->getCategoryIds();
-            $productCategories = array_intersect(array_keys($categories), $productCategories);
-            $existingProductsToCollectionsMap[$product->getId()] = $this->getYotpoCollectionsMap($yotpoProductId);
-
-            foreach ($productCategories as $categoryId) {
-                $productIdsToCategoriesIdsMap[$product->getId()][] = $categoryId;
-                $categories[$categoryId]->setData(
-                    'nameWithPath',
-                    $this->getNameWithPath($categories[$categoryId], $categoriesByPath)
-                );
-                if (!array_key_exists($categoryId, $existingCollections)) {
-                    $collectionData = $this->data->prepareData($categories[$categoryId]);
-                    $collectionData['entityLog'] = 'catalog';
-                    $yotpoCollectionId = $this->createOrUpdateCollection($collectionData, $categoryId, $categories);
-                    if ($yotpoCollectionId) {
-                        $existingCollections[$categoryId]['yotpo_id'] = $yotpoCollectionId;
-                        $newCollectionsToLog[] = $categoryId;
-                    } else {
-                        $existingCollections[$categoryId] = '';
-                        $yotpoCollectionId = '';
-                    }
-                } else {
-                    $yotpoCollectionId = $existingCollections[$categoryId]['yotpo_id'];
-                }
-
-                if ($yotpoCollectionId
-                    && $this->canAddProductToCollection(
-                        $yotpoCollectionId,
-                        $categoryId,
-                        $existingProductsToCollectionsMap,
-                        $product->getId()
-                    )) {
-                    $this->assignProductCategoryForCollectionsProductsSync($product, $categoryId);
-                }
-            }
-            $existingProductsToCollectionsMap[$product->getId()] = array_filter($existingProductsToCollectionsMap[$product->getId()]);
-            $existingCategoriesIds = array_keys($existingProductsToCollectionsMap[$product->getId()]);
-            $deletedCategoriesIds = array_diff($existingCategoriesIds, $productIdsToCategoriesIdsMap[$product->getId()]);
+        foreach ($productItems as $productItem) {
+            $productId = $productItem->getId();
             $this->yotpoCoreCatalogLogger->info(
-                'Category Sync by product -  unassign products - Category IDs -
-                    ' . implode(',', array_unique($deletedCategoriesIds)),
-                []
+                __(
+                    'Product Sync - Setting product collections sync for product ID %1',
+                    $productId
+                )
             );
 
-            $this->assignProductCategoriesForCollectionsProductsSyncAsDeleted($product, $deletedCategoriesIds);
-        }
-        $this->yotpoCoreCatalogLogger->info(
-            'Category Sync by product -  Finished - Category ID - ' . implode(',', array_unique($newCollectionsToLog)),
-            []
-        );
-    }
+            $productCategoriesIds = $productItem->getCategoryIds();
+            $categoryIdsSyncedForProduct = $this->collectionsProductsService->getCategoryIdsFromSyncTableByProductId($productId);
 
-    /**
-     * @param int $collectionId
-     * @param int $categoryId
-     * @param array<mixed> $existingProducts
-     * @param int $productId
-     * @return bool
-     */
-    protected function canAddProductToCollection($collectionId, $categoryId, $existingProducts, $productId)
-    {
-        if (!array_key_exists($categoryId, $existingProducts[$productId])) {
-            return true;
+            foreach ($productCategoriesIds as $categoryId) {
+                if (in_array($categoryId, $categoryIdsSyncedForProduct)) {
+                    continue;
+                }
+
+                $this->assignProductCategoryForCollectionsProductsSync($productItem, $categoryId);
+            }
+
+            $deletedCategoryIdsFromProduct = array_diff($categoryIdsSyncedForProduct, $productCategoriesIds);
+            $this->assignProductCategoriesForCollectionsProductsSyncAsDeleted($productItem, $deletedCategoryIdsFromProduct);
         }
-        if (isset($existingProducts[$productId][$categoryId]) &&
-            $existingProducts[$productId][$categoryId] != $collectionId
-        ) {
-            return true;
-        }
-        return false;
     }
 
     /**
@@ -143,110 +56,6 @@ class ProcessByProduct extends Main
     }
 
     /**
-     * @param Category $category
-     * @return int
-     * @throws NoSuchEntityException
-     */
-    public function createCollection(Category $category)
-    {
-        $currentTime = date('Y-m-d H:i:s');
-        $categoryId = $category->getId();
-        $existingCollection = $this->getExistingCollectionIds([$categoryId]);
-        $yotpoTableData = [];
-        $yotpoTableData['store_id'] = $this->config->getStoreId();
-        $yotpoTableData['category_id'] = $category->getId();
-        $yotpoTableData['synced_to_yotpo'] = $currentTime;
-        if (!$existingCollection) {
-            $response = $this->syncAsNewCollection($category);
-            $yotpoId = $this->getYotpoIdFromCreateCollectionResponse($response);
-            $yotpoTableRespData = $response ? $this->prepareYotpoTableData($response) : [];
-            if ($yotpoTableRespData && is_array($yotpoTableRespData)) {
-                $yotpoTableData = array_merge($yotpoTableData, $yotpoTableRespData);
-            }
-            $this->insertOrUpdateYotpoTableData($yotpoTableData);
-        } else {
-            $yotpoId = array_key_exists($categoryId, $existingCollection) ?
-                $existingCollection[$categoryId] : 0;
-            $yotpoTableData['yotpo_id'] = $yotpoId;
-            $yotpoTableData['response_code'] = YotpoCoreConfig::SUCCESS_RESPONSE_CODE;
-        }
-        if ($yotpoId) {
-            $this->insertOrUpdateYotpoTableData($yotpoTableData);
-        }
-        return $yotpoId;
-    }
-
-    /**
-     * @param string $yotpoProductId
-     * @return  array<mixed>
-     * @throws NoSuchEntityException
-     */
-    public function getYotpoCollectionsMap($yotpoProductId): array
-    {
-        $return = [];
-        $data = [];
-        if ($yotpoProductId) {
-            $url = $this->config->getEndpoint(
-                'collections_for_product',
-                ['{yotpo_product_id}'],
-                [$yotpoProductId]
-            );
-            $data['entityLog'] = 'catalog';
-            $collections = $this->yotpoCoreApiSync->sync(Request::HTTP_METHOD_GET, $url, $data);
-            $collections = $collections->getData('response');
-            if (!$collections) {
-                return $return;
-            }
-            $collections = is_array($collections) &&
-            isset($collections['collections']) ?
-                $collections['collections'] : '';
-            if ($collections) {
-                $count = count($collections);
-                for ($i = 0; $i < $count; $i++) {
-                    $return[$collections[$i]['external_id']] = $collections[$i]['yotpo_id'];
-                    $this->existingCollectionsInYotpo[$collections[$i]['external_id']] = [
-                        'yotpo_id' => $collections[$i]['yotpo_id'],
-                        'name' => $collections[$i]['name']
-                    ];
-                }
-            }
-        }
-        return $return;
-    }
-
-    /**
-     * @param array<mixed> $products
-     * @return array<mixed>
-     */
-    protected function prepareCategories(array $products): array
-    {
-        $returnCategories = [];
-        $categoryIds = [];
-        foreach ($products as $product) {
-            $categories = $product->getCategoryIds();
-            $categoryIds[] = $categories;
-        }
-
-        $categoryIds = array_merge(...$categoryIds);
-        $categoryIds = array_unique(array_filter($categoryIds));
-
-        if ($categoryIds) {
-            $collection = $this->getStoreCategoryCollection();
-            $collection->addIdFilter($categoryIds);
-
-            foreach ($collection->getItems() as $category) {
-                $returnCategories[$category->getId()] = $category;
-            }
-        }
-        $this->yotpoCoreCatalogLogger->info(
-            'Category Sync - Process categories by product -
-                    ' . implode(',', array_unique(array_keys($returnCategories))),
-            []
-        );
-        return $returnCategories;
-    }
-
-    /**
      * @param Product $product
      * @param array $deletedCategoriesIds
      * @return void
@@ -258,115 +67,5 @@ class ProcessByProduct extends Main
         foreach ($deletedCategoriesIds as $deletedCategoryId) {
             $this->collectionsProductsService->assignCategoryProductsForCollectionsProductsSync([$productId], $productStoreId, $deletedCategoryId, true);
         }
-    }
-
-    /**
-     * @param array<mixed> $newCollections
-     * @return void
-     * @throws NoSuchEntityException
-     */
-    public function addNewCollectionsToYotpoTable(array $newCollections)
-    {
-        foreach ($newCollections as $categoryId => $collection) {
-            $finalData = [
-                'category_id' => $categoryId,
-                'synced_to_yotpo' => $collection['synced_to_yotpo'],
-                'response_code' => '201',
-                'yotpo_id' => $collection['yotpo_id'],
-                'store_id' => $this->config->getStoreId()
-            ];
-            $this->insertOrUpdateYotpoTableData($finalData);
-        }
-    }
-
-    /**
-     * @param array<mixed> $collectionData
-     * @param int $categoryId
-     * @param array<mixed> $categories
-     * @return mixed|string
-     * @throws NoSuchEntityException
-     * @throws LocalizedException
-     */
-    public function createOrUpdateCollection($collectionData, $categoryId, $categories)
-    {
-        $newCollections = null;
-        $categoryIdToUpdate = null;
-        $currentTime = date('Y-m-d H:i:s');
-        $url = $this->config->getEndpoint('collections');
-        $yotpoIdToReturn = $this->updateIfNameIsDifferent($this->existingCollectionsInYotpo, $categories, $categoryId);
-        if ($yotpoIdToReturn) {
-            $newCollections = [];
-            $newCollections[$categoryId] = [
-                'yotpo_id' => $yotpoIdToReturn,
-                'synced_to_yotpo' => $currentTime
-            ];
-            $categoryIdToUpdate = $categories[$categoryId]->getRowId()
-                ?: $categories[$categoryId]->getId();
-        } else {
-            $newCollectionResponse = $this->yotpoCoreApiSync->sync(
-                Request::HTTP_METHOD_POST,
-                $url,
-                $collectionData
-            );
-            if (!$newCollectionResponse) {
-                return $yotpoIdToReturn;
-            }
-            if ($this->checkForCollectionExistsError($newCollectionResponse)) {
-                $existingCollections = $this->getExistingCollection([$categoryId]);
-                $yotpoIdToReturn = $this->updateIfNameIsDifferent($existingCollections, $categories, $categoryId);
-                if ($yotpoIdToReturn) {
-                    $newCollections = [];
-                    $newCollections[$categoryId] = [
-                        'yotpo_id' => $yotpoIdToReturn,
-                        'synced_to_yotpo' => $currentTime
-                    ];
-                    $categoryIdToUpdate = $categories[$categoryId]->getRowId()
-                        ?: $categories[$categoryId]->getId();
-                }
-            } else {
-                $yotpoIdToReturn = $this->getYotpoIdFromCreateCollectionResponse($newCollectionResponse);
-                $newCollections = [];
-                $newCollections[$categoryId] = [
-                    'yotpo_id' => $yotpoIdToReturn,
-                    'synced_to_yotpo' => $currentTime
-                ];
-                $categoryIdToUpdate = $categories[$categoryId]->getRowId()
-                    ?: $categories[$categoryId]->getId();
-            }
-        }
-        if ($categoryIdToUpdate) {
-            $this->updateCategoryAttribute($categoryIdToUpdate);
-        }
-        if ($newCollections) {
-            $this->addNewCollectionsToYotpoTable($newCollections);
-        }
-        return $yotpoIdToReturn;
-    }
-
-    /**
-     * @param array <mixed> $existingProdCollYotpo
-     * @param array<mixed> $categories
-     * @param int $categoryId
-     * @return int|string|null
-     * @throws LocalizedException
-     * @throws NoSuchEntityException
-     */
-    public function updateIfNameIsDifferent($existingProdCollYotpo, $categories, $categoryId)
-    {
-        $yotpoIdToReturn = null;
-        if (array_key_exists($categoryId, $existingProdCollYotpo)) {
-            $nameWithPath = $categories[$categoryId]->getData('nameWithPath');
-            if ($existingProdCollYotpo[$categoryId]['name'] != $nameWithPath) {
-                //update the collection
-                $response = $this->syncExistingOrNewCollection(
-                    $categories[$categoryId],
-                    $existingProdCollYotpo[$categoryId]['yotpo_id']
-                );
-                $yotpoIdToReturn = $this->getYotpoIdFromCreateCollectionResponse($response);
-            } else {
-                $yotpoIdToReturn = $existingProdCollYotpo[$categoryId]['yotpo_id'];
-            }
-        }
-        return $yotpoIdToReturn;
     }
 }

--- a/Model/Sync/Category/Processor/ProcessByProduct.php
+++ b/Model/Sync/Category/Processor/ProcessByProduct.php
@@ -28,7 +28,7 @@ class ProcessByProduct extends Main
     /**
      * @var array <mixed>
      */
-    protected $prodCollExistYotpo = [];
+    protected $existingCollectionsInYotpo = [];
 
     /**
      * @param array<mixed> $products
@@ -255,7 +255,7 @@ class ProcessByProduct extends Main
                 $count = count($collections);
                 for ($i = 0; $i < $count; $i++) {
                     $return[$collections[$i]['external_id']] = $collections[$i]['yotpo_id'];
-                    $this->prodCollExistYotpo[$collections[$i]['external_id']] = [
+                    $this->existingCollectionsInYotpo[$collections[$i]['external_id']] = [
                         'yotpo_id' => $collections[$i]['yotpo_id'],
                         'name' => $collections[$i]['name']
                     ];
@@ -344,7 +344,7 @@ class ProcessByProduct extends Main
         $categoryIdToUpdate = null;
         $currentTime = date('Y-m-d H:i:s');
         $url = $this->config->getEndpoint('collections');
-        $yotpoIdToReturn = $this->updateIfNameIsDifferent($this->prodCollExistYotpo, $categories, $categoryId);
+        $yotpoIdToReturn = $this->updateIfNameIsDifferent($this->existingCollectionsInYotpo, $categories, $categoryId);
         if ($yotpoIdToReturn) {
             $newCollections = [];
             $newCollections[$categoryId] = [

--- a/Model/Sync/Category/Processor/ProcessByProduct.php
+++ b/Model/Sync/Category/Processor/ProcessByProduct.php
@@ -409,7 +409,7 @@ class ProcessByProduct extends Main
             $nameWithPath = $categories[$categoryId]->getData('nameWithPath');
             if ($existingProdCollYotpo[$categoryId]['name'] != $nameWithPath) {
                 //update the collection
-                $response = $this->syncExistingCollection(
+                $response = $this->syncExistingOrNewCollection(
                     $categories[$categoryId],
                     $existingProdCollYotpo[$categoryId]['yotpo_id']
                 );

--- a/Model/Sync/Category/Processor/ProcessByProduct.php
+++ b/Model/Sync/Category/Processor/ProcessByProduct.php
@@ -38,8 +38,8 @@ class ProcessByProduct extends Main
     public function process(array $products = [])
     {
         $this->yotpoCoreCatalogLogger->info('Category Sync - Process categories by product - START ', []);
-        $categories             =   $this->prepareCategories($products);
-        $existingCollections    =   $this->getYotpoSyncedCategories(array_keys($categories));
+        $categories = $this->prepareCategories($products);
+        $existingCollections = $this->getYotpoSyncedCategories(array_keys($categories));
         $newCollectionsToLog = [];
 
         foreach ($existingCollections as $catId => $cat) {
@@ -51,37 +51,37 @@ class ProcessByProduct extends Main
                 unset($categories[$catId]);
             }
         }
-        $categoriesByPath       =   $this->getCategoriesFromPathNames(array_values($categories));
-        $existingProductsMap    =   [];
-        $categoriesProduct      =   [];
+        $categoriesByPath = $this->getCategoriesFromPathNames(array_values($categories));
+        $existingProductsMap = [];
+        $categoriesProduct = [];
 
         foreach ($products as $yotpoProductId => $product) {
-            /** @var Product $product **/
-            $categoriesProduct[$product->getId()]   =   [];
-            $productCategories                      =   $product->getCategoryIds();
-            $productCategories                      =   array_intersect(array_keys($categories), $productCategories);
-            $existingProductsMap[$product->getId()] =   $this->getYotpoCollectionsMap($yotpoProductId);
-            $addProductData                         =   $this->data->prepareProductData($product->getId());
+            /** @var Product $product * */
+            $categoriesProduct[$product->getId()] = [];
+            $productCategories = $product->getCategoryIds();
+            $productCategories = array_intersect(array_keys($categories), $productCategories);
+            $existingProductsMap[$product->getId()] = $this->getYotpoCollectionsMap($yotpoProductId);
+            $addProductData = $this->data->prepareProductData($product->getId());
 
             foreach ($productCategories as $categoryId) {
-                $categoriesProduct[$product->getId()][] =   $categoryId;
+                $categoriesProduct[$product->getId()][] = $categoryId;
                 $categories[$categoryId]->setData(
                     'nameWithPath',
                     $this->getNameWithPath($categories[$categoryId], $categoriesByPath)
                 );
                 if (!array_key_exists($categoryId, $existingCollections)) {
-                    $collectionData                 =   $this->data->prepareData($categories[$categoryId]);
-                    $collectionData['entityLog']    = 'catalog';
+                    $collectionData = $this->data->prepareData($categories[$categoryId]);
+                    $collectionData['entityLog'] = 'catalog';
                     $yotpoCollectionId = $this->createOrUpdateCollection($collectionData, $categoryId, $categories);
                     if ($yotpoCollectionId) {
                         $existingCollections[$categoryId]['yotpo_id'] = $yotpoCollectionId;
                         $newCollectionsToLog[] = $categoryId;
                     } else {
-                        $existingCollections[$categoryId]   =   '';
-                        $yotpoCollectionId  =   '';
+                        $existingCollections[$categoryId] = '';
+                        $yotpoCollectionId = '';
                     }
                 } else {
-                    $yotpoCollectionId  =   $existingCollections[$categoryId]['yotpo_id'];
+                    $yotpoCollectionId = $existingCollections[$categoryId]['yotpo_id'];
                 }
 
                 if ($yotpoCollectionId
@@ -99,12 +99,12 @@ class ProcessByProduct extends Main
                         $categories,
                         $existingProductsMap
                     );
-                    $existingProductsMap[$product->getId()][$categoryId]   =   $yotpoCollectionId ?: 0;
+                    $existingProductsMap[$product->getId()][$categoryId] = $yotpoCollectionId ?: 0;
                 }
             }
             $existingProductsMap[$product->getId()] = array_filter($existingProductsMap[$product->getId()]);
-            $currentMap     =   array_keys($existingProductsMap[$product->getId()]);
-            $catUnmap       =   array_diff($currentMap, $categoriesProduct[$product->getId()]);
+            $currentMap = array_keys($existingProductsMap[$product->getId()]);
+            $catUnmap = array_diff($currentMap, $categoriesProduct[$product->getId()]);
             $this->yotpoCoreCatalogLogger->info(
                 'Category Sync by product -  unassign products - Category IDs -
                     ' . implode(',', array_unique($catUnmap)),
@@ -158,12 +158,12 @@ class ProcessByProduct extends Main
         $existingProductsMap
     ) {
         $yotpoCollectionIdReturn = $yotpoCollectionId;
-        $addProductUrl  =   $this->config->getEndpoint(
+        $addProductUrl = $this->config->getEndpoint(
             'collections_product',
             ['{yotpo_collection_id}'],
             [$yotpoCollectionId]
         );
-        $addProductData['entityLog']    =   'catalog';
+        $addProductData['entityLog'] = 'catalog';
         $response = $this->yotpoCoreApiSync->sync(Request::HTTP_METHOD_POST, $addProductUrl, $addProductData);
         $storeId = $product->getStoreId();
         if ($this->isImmediateRetry($response, $this->entity, $categoryId, $storeId)) {
@@ -195,8 +195,8 @@ class ProcessByProduct extends Main
 
     /**
      * @param Category $category
-     * @throws NoSuchEntityException
      * @return int
+     * @throws NoSuchEntityException
      */
     public function createCollection(Category $category)
     {
@@ -206,7 +206,7 @@ class ProcessByProduct extends Main
         $yotpoTableData = [];
         $yotpoTableData['store_id'] = $this->config->getStoreId();
         $yotpoTableData['category_id'] = $category->getId();
-        $yotpoTableData['synced_to_yotpo'] =  $currentTime;
+        $yotpoTableData['synced_to_yotpo'] = $currentTime;
         if (!$existingCollection) {
             $response = $this->syncAsNewCollection($category);
             $yotpoId = $this->getYotpoIdFromResponse($response);
@@ -217,9 +217,9 @@ class ProcessByProduct extends Main
             $this->insertOrUpdateYotpoTableData($yotpoTableData);
         } else {
             $yotpoId = array_key_exists($categoryId, $existingCollection) ?
-                $existingCollection[$categoryId]  : 0;
+                $existingCollection[$categoryId] : 0;
             $yotpoTableData['yotpo_id'] = $yotpoId;
-            $yotpoTableData['response_code'] =  YotpoCoreConfig::SUCCESS_RESPONSE_CODE;
+            $yotpoTableData['response_code'] = YotpoCoreConfig::SUCCESS_RESPONSE_CODE;
         }
         if ($yotpoId) {
             $this->insertOrUpdateYotpoTableData($yotpoTableData);
@@ -235,25 +235,25 @@ class ProcessByProduct extends Main
     public function getYotpoCollectionsMap($yotpoProductId): array
     {
         $return = [];
-        $data   = [];
+        $data = [];
         if ($yotpoProductId) {
-            $url    =   $this->config->getEndpoint(
+            $url = $this->config->getEndpoint(
                 'collections_for_product',
                 ['{yotpo_product_id}'],
                 [$yotpoProductId]
             );
-            $data['entityLog']  =   'catalog';
-            $collections        =   $this->yotpoCoreApiSync->sync(Request::HTTP_METHOD_GET, $url, $data);
-            $collections        =   $collections->getData('response');
+            $data['entityLog'] = 'catalog';
+            $collections = $this->yotpoCoreApiSync->sync(Request::HTTP_METHOD_GET, $url, $data);
+            $collections = $collections->getData('response');
             if (!$collections) {
                 return $return;
             }
-            $collections    =   is_array($collections) &&
+            $collections = is_array($collections) &&
             isset($collections['collections']) ?
                 $collections['collections'] : '';
             if ($collections) {
                 $count = count($collections);
-                for ($i=0; $i<$count; $i++) {
+                for ($i = 0; $i < $count; $i++) {
                     $return[$collections[$i]['external_id']] = $collections[$i]['yotpo_id'];
                     $this->prodCollExistYotpo[$collections[$i]['external_id']] = [
                         'yotpo_id' => $collections[$i]['yotpo_id'],
@@ -271,22 +271,22 @@ class ProcessByProduct extends Main
      */
     protected function prepareCategories(array $products): array
     {
-        $returnCategories   =   [];
-        $categoryIds        =   [];
+        $returnCategories = [];
+        $categoryIds = [];
         foreach ($products as $product) {
-            $categories     =   $product->getCategoryIds();
-            $categoryIds[]    =  $categories;
+            $categories = $product->getCategoryIds();
+            $categoryIds[] = $categories;
         }
 
         $categoryIds = array_merge(...$categoryIds);
-        $categoryIds    =   array_unique(array_filter($categoryIds));
+        $categoryIds = array_unique(array_filter($categoryIds));
 
         if ($categoryIds) {
-            $collection =   $this->getStoreCategoryCollection();
+            $collection = $this->getStoreCategoryCollection();
             $collection->addIdFilter($categoryIds);
 
             foreach ($collection->getItems() as $category) {
-                $returnCategories[$category->getId()]   =   $category;
+                $returnCategories[$category->getId()] = $category;
             }
         }
         $this->yotpoCoreCatalogLogger->info(
@@ -306,11 +306,11 @@ class ProcessByProduct extends Main
     {
         foreach ($newCollections as $categoryId => $collection) {
             $finalData = [
-                'category_id'        =>  $categoryId,
-                'synced_to_yotpo'    =>  $collection['synced_to_yotpo'],
-                'response_code'      =>  '201',
-                'yotpo_id'           =>  $collection['yotpo_id'],
-                'store_id'           =>  $this->config->getStoreId()
+                'category_id' => $categoryId,
+                'synced_to_yotpo' => $collection['synced_to_yotpo'],
+                'response_code' => '201',
+                'yotpo_id' => $collection['yotpo_id'],
+                'store_id' => $this->config->getStoreId()
             ];
             $this->insertOrUpdateYotpoTableData($finalData);
         }
@@ -325,7 +325,7 @@ class ProcessByProduct extends Main
     public function unAssignProducts(array $catUnmap, int $productId, array $existingProductsMap)
     {
         foreach ($catUnmap as $catId) {
-            $yotpoId    =   $existingProductsMap[$catId];
+            $yotpoId = $existingProductsMap[$catId];
             $this->unAssignProductFromCollection($yotpoId, $productId);
         }
     }
@@ -351,7 +351,7 @@ class ProcessByProduct extends Main
                 'yotpo_id' => $yotpoIdToReturn,
                 'synced_to_yotpo' => $currentTime
             ];
-            $categoryIdToUpdate   =   $categories[$categoryId]->getRowId()
+            $categoryIdToUpdate = $categories[$categoryId]->getRowId()
                 ?: $categories[$categoryId]->getId();
         } else {
             $createCollection = $this->yotpoCoreApiSync->sync(
@@ -372,7 +372,7 @@ class ProcessByProduct extends Main
                         'yotpo_id' => $yotpoIdToReturn,
                         'synced_to_yotpo' => $currentTime
                     ];
-                    $categoryIdToUpdate   =   $categories[$categoryId]->getRowId()
+                    $categoryIdToUpdate = $categories[$categoryId]->getRowId()
                         ?: $categories[$categoryId]->getId();
                 }
             } else {
@@ -382,7 +382,7 @@ class ProcessByProduct extends Main
                     'yotpo_id' => $yotpoIdToReturn,
                     'synced_to_yotpo' => $currentTime
                 ];
-                $categoryIdToUpdate   =   $categories[$categoryId]->getRowId()
+                $categoryIdToUpdate = $categories[$categoryId]->getRowId()
                     ?: $categories[$categoryId]->getId();
             }
         }

--- a/Model/Sync/CollectionsProducts/Cron/CollectionsProductsSync.php
+++ b/Model/Sync/CollectionsProducts/Cron/CollectionsProductsSync.php
@@ -1,0 +1,37 @@
+<?php
+namespace Yotpo\Core\Model\Sync\CollectionsProducts\Cron;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Yotpo\Core\Model\Sync\CollectionsProducts\Processor as Processor;
+
+/**
+ * Class CollectionsProductsSync - Trigger Catalog sync - Scheduled Job
+ */
+class CollectionsProductsSync
+{
+    /**
+     * @var Processor
+     */
+    protected $processor;
+
+    /**
+     * CatalogSync constructor.
+     * @param Processor $processor
+     */
+    public function __construct(
+        Processor $processor
+    ) {
+        $this->processor = $processor;
+    }
+
+    /**
+     * @throws NoSuchEntityException
+     * @throws LocalizedException
+     * @return void
+     */
+    public function execute()
+    {
+        $this->processor->process();
+    }
+}

--- a/Model/Sync/CollectionsProducts/Processor.php
+++ b/Model/Sync/CollectionsProducts/Processor.php
@@ -209,7 +209,7 @@ class Processor extends AbstractJobs
      */
     private function syncCollectionAndGetCreatedYotpoId($magentoCategoryId, $storeId)
     {
-        $this->yotpoCategoryProcessor->processEntity($magentoCategoryId, $storeId);
+        $this->yotpoCategoryProcessor->processEntities($magentoCategoryId, $storeId);
         $collectionYotpoId = $this->yotpoCategoryProcessorMain->getYotpoIdFromCategoriesSyncTableByCategoryId($magentoCategoryId);
         if (!$collectionYotpoId) {
             return null;

--- a/Model/Sync/CollectionsProducts/Processor.php
+++ b/Model/Sync/CollectionsProducts/Processor.php
@@ -2,10 +2,391 @@
 
 namespace Yotpo\Core\Model\Sync\CollectionsProducts;
 
-class Processor
+use Exception;
+use Yotpo\Core\Model\AbstractJobs;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Store\Model\App\Emulation as AppEmulation;
+use Yotpo\Core\Model\Api\Sync as YotpoCoreSync;
+use Yotpo\Core\Model\Config as CoreConfig;
+use Yotpo\Core\Model\Sync\Catalog\Logger as CatalogLogger;
+use Yotpo\Core\Model\Sync\Catalog\YotpoResource;
+use Yotpo\Core\Model\Sync\CollectionsProducts\Services\CollectionsProductsService;
+use Yotpo\Core\Model\Sync\Category\Processor\Main as YotpoCategoryProcessorMain;
+use Yotpo\Core\Model\Sync\Category\Processor\ProcessByCategory as YotpoCategoryProcessor;
+use Yotpo\Core\Model\Sync\Catalog\Processor as YotpoProductProcessor;
+use Yotpo\Core\Model\Sync\Catalog\Processor\Main as YotpoProductProcessorMain;
+
+class Processor extends AbstractJobs
 {
+    const PRODUCT_SYNC_LIMIT_CONFIG_KEY = 'product_sync_limit';
+    const COLLECTIONS_PRODUCT_ENDPOINT_STRING = 'collections_product';
+    const YOTPO_COLLECTION_ID_REQUEST_PARAM_STRING = '{yotpo_collection_id}';
+    const LOGGER_LOG_ENTITY_FILE = 'catalog';
+
+    /**
+     * @var CoreConfig
+     */
+    protected $coreConfig;
+
+    /**
+     * @var YotpoCoreSync
+     */
+    protected $yotpoCoreSync;
+
+    /**
+     * @var CatalogLogger
+     */
+    protected $catalogLogger;
+
+    /**
+     * @var YotpoResource
+     */
+    protected $yotpoResource;
+
+    /**
+     * @var YotpoCategoryProcessorMain
+     */
+    protected $yotpoCategoryProcessorMain;
+
+    /**
+     * @var YotpoCategoryProcessor
+     */
+    protected $yotpoCategoryProcessor;
+
+    /**
+     * @var YotpoProductProcessorMain
+     */
+    protected $yotpoProductProcessorMain;
+
+    /**
+     * @var YotpoProductProcessor
+     */
+    protected $yotpoProductProcessor;
+
+    /**
+     * @var CollectionsProductsService
+     */
+    protected $collectionsProductsService;
+
+    /**
+     * @var int
+     */
+    protected $collectionsProductsSyncBatchSize = null;
+
+    /**
+     * Processor constructor.
+     * @param AppEmulation $appEmulation
+     * @param ResourceConnection $resourceConnection
+     * @param CoreConfig $coreConfig
+     * @param YotpoCoreSync $yotpoCoreSync
+     * @param CatalogLogger $catalogLogger
+     * @param YotpoResource $yotpoResource
+     * @param YotpoCategoryProcessorMain $yotpoCategoryProcessorMain
+     * @param YotpoCategoryProcessor $yotpoCategoryProcessor
+     * @param YotpoProductProcessorMain $yotpoProductProcessorMain
+     * @param YotpoProductProcessor $yotpoProductProcessor
+     * @param CollectionsProductsService $collectionsProductsService
+    **/
+    public function __construct(
+        AppEmulation $appEmulation,
+        ResourceConnection $resourceConnection,
+        CoreConfig $coreConfig,
+        YotpoCoreSync $yotpoCoreSync,
+        CatalogLogger $catalogLogger,
+        YotpoResource $yotpoResource,
+        YotpoCategoryProcessorMain $yotpoCategoryProcessorMain,
+        YotpoCategoryProcessor $yotpoCategoryProcessor,
+        YotpoProductProcessorMain $yotpoProductProcessorMain,
+        YotpoProductProcessor $yotpoProductProcessor,
+        CollectionsProductsService $collectionsProductsService
+    ) {
+        $this->coreConfig = $coreConfig;
+        $this->yotpoCoreSync = $yotpoCoreSync;
+        $this->catalogLogger = $catalogLogger;
+        $this->yotpoResource = $yotpoResource;
+        $this->yotpoCategoryProcessorMain = $yotpoCategoryProcessorMain;
+        $this->yotpoCategoryProcessor = $yotpoCategoryProcessor;
+        $this->yotpoProductProcessorMain = $yotpoProductProcessorMain;
+        $this->yotpoProductProcessor = $yotpoProductProcessor;
+        $this->collectionsProductsService = $collectionsProductsService;
+        $this->collectionsProductsSyncBatchSize = $this->coreConfig->getConfig($this::PRODUCT_SYNC_LIMIT_CONFIG_KEY);
+        parent::__construct($appEmulation, $resourceConnection);
+    }
+
     public function process()
     {
+        $storeIdsList = (array) $this->coreConfig->getAllStoreIds();
 
+        foreach ($storeIdsList as $storeId) {
+            try {
+                $this->emulateFrontendArea($storeId);
+                if (!$this->shouldSyncCollectionsProducts()) {
+                    $this->catalogLogger->info(
+                        __(
+                            'Collections Products Sync - Sync for store is disabled - Magento Store ID: %1, Magento Store Name: %2',
+                            $storeId,
+                            $this->coreConfig->getStoreName($storeId)
+                        )
+                    );
+
+                    continue;
+                }
+
+                $this->catalogLogger->info(
+                    __(
+                        'Collections Products Sync - Starting sync for store - Magento Store ID: %1, Magento Store Name: %2',
+                        $storeId,
+                        $this->coreConfig->getStoreName($storeId)
+                    )
+                );
+
+                $collectionsProductsEntitiesToSync = $this->collectionsProductsService->getCollectionsProductsToSync($this->collectionsProductsSyncBatchSize);
+                if (!$collectionsProductsEntitiesToSync) {
+                    $this->logFinishedCollectionsProductsSync($storeId);
+                    continue;
+                }
+
+                $enrichedCollectionsProductsEntitiesToSync = $this->enrichCollectionsProductsDataWithYotpoIds($collectionsProductsEntitiesToSync);
+                $this->syncCollectionsProductsEntitiesToYotpo($enrichedCollectionsProductsEntitiesToSync, $storeId);
+                $this->logFinishedCollectionsProductsSync($storeId);
+            } catch (Exception $exception) {
+                $this->catalogLogger->info(
+                    __(
+                        'Collections Products Sync - Stopped sync for store - Magento Store ID: %1, Magento Store Name: %2, Exception: %3',
+                        $storeId,
+                        $this->coreConfig->getStoreName($storeId),
+                        $exception->getMessage()
+                    )
+                );
+            } finally {
+                $this->stopEnvironmentEmulation();
+            }
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    private function shouldSyncCollectionsProducts()
+    {
+        return $this->coreConfig->isEnabled() && $this->coreConfig->isCatalogSyncActive();
+    }
+
+    /**
+     * @param array $collectionProductEntityToSync
+     * @return array
+     */
+    private function prepareCollectionProductToSync($collectionProductEntityToSync)
+    {
+        return [
+            'product' => [
+                'external_id' => $collectionProductEntityToSync['magento_product_id']
+            ]
+        ];
+    }
+
+    /**
+     * @param string $requestEndpoint
+     * @param array $collectionProductDataToSync
+     * @param boolean $isCollectionProductIsDeletedInMagento
+     * @return mixed
+     */
+    private function syncCollectionProductToYotpo($requestEndpoint, array $collectionProductDataToSync, $isCollectionProductIsDeletedInMagento)
+    {
+        if ($isCollectionProductIsDeletedInMagento) {
+            $response = $this->yotpoCoreSync->sync($this->coreConfig::METHOD_DELETE, $requestEndpoint, $collectionProductDataToSync);
+        } else {
+            $response = $this->yotpoCoreSync->sync($this->coreConfig::METHOD_POST, $requestEndpoint, $collectionProductDataToSync);
+        }
+
+        return $response;
+    }
+
+    /**
+     * @param string $magentoCategoryId
+     * @param string $storeId
+     * @return string|null
+     */
+    private function syncCollectionAndGetCreatedYotpoId($magentoCategoryId, $storeId)
+    {
+        $this->yotpoCategoryProcessor->processEntity($magentoCategoryId, $storeId);
+        $collectionYotpoId = $this->yotpoCategoryProcessorMain->getYotpoIdFromCategoriesSyncTableByCategoryId($magentoCategoryId);
+        if (!$collectionYotpoId) {
+            return null;
+        }
+
+        return $collectionYotpoId;
+    }
+
+    /**
+     * @param string $magentoProductId
+     * @param string $storeId
+     * @return string|null
+     */
+    private function syncProductAndGetCreatedYotpoId($magentoProductId, $storeId)
+    {
+        $this->yotpoProductProcessorMain->setNormalSyncFlag(false);
+        $unSyncedProductIds = [$storeId => [$magentoProductId]];
+        $this->yotpoProductProcessor->process($unSyncedProductIds, [$storeId]);
+        $productYotpoId = $this->yotpoProductProcessorMain->getYotpoIdFromProductsSyncTableByProductId($magentoProductId);
+        if (!$productYotpoId) {
+            return null;
+        }
+
+        return $productYotpoId;
+    }
+
+    /**
+     * @param string $storeId
+     * @param array $collectionProductEntityToSync
+     * @return void
+     */
+    private function setAsSuccessfulCollectionProductSync($storeId, $collectionProductEntityToSync)
+    {
+        $this->collectionsProductsService->updateCollectionsProductsSyncDataAsSyncedToYotpo($storeId, $collectionProductEntityToSync);
+
+        $this->catalogLogger->info(
+            __(
+                'Collections Products Sync - Synced Collection Product to Yotpo successfully -
+                     Magento Store ID: %1
+                     Magento Store Name: %2, 
+                     Magento Category ID: %3, 
+                     Magento Product ID: %4',
+                $storeId,
+                $this->coreConfig->getStoreName($storeId),
+                $collectionProductEntityToSync['magento_category_id'],
+                $collectionProductEntityToSync['magento_product_id']
+            )
+        );
+    }
+
+    /**
+     * @param string $storeId
+     * @return void
+     */
+    private function logFinishedCollectionsProductsSync($storeId)
+    {
+        $this->catalogLogger->info(
+            __(
+                'Collections Products Sync - Finished sync for store - Magento Store ID: %1, Magento Store Name: %2',
+                $storeId,
+                $this->coreConfig->getStoreName($storeId)
+            )
+        );
+    }
+
+    /**
+     * @param array $collectionsProductsEntitiesToSync
+     * @return array
+     */
+    private function enrichCollectionsProductsDataWithYotpoIds(array $collectionsProductsEntitiesToSync)
+    {
+        $collectionsProductsCategoriesIds = [];
+        $collectionsProductsProductIds = [];
+        foreach ($collectionsProductsEntitiesToSync as $collectionProductEntityToSync) {
+            $collectionsProductsCategoriesIds[] = $collectionProductEntityToSync['magento_category_id'];
+            $collectionsProductsProductIds[] = $collectionProductEntityToSync['magento_product_id'];
+        }
+
+        $collectionsProductsCategoriesIds = array_unique($collectionsProductsCategoriesIds);
+        $collectionsProductsProductIds = array_unique($collectionsProductsProductIds);
+
+        $enrichedCollectionsProductsEntitiesToSync = [];
+        $collectionsProductsCategoriesIdsToYotpoIdsMap = $this->yotpoCategoryProcessorMain->getYotpoIdsFromCategoriesSyncTableByCategoryIds($collectionsProductsCategoriesIds);
+        $collectionsProductsProductIdToYotpoIdsMap = $this->yotpoProductProcessorMain->getYotpoIdsFromProductsSyncTableByProductIds($collectionsProductsProductIds);
+        foreach ($collectionsProductsEntitiesToSync as $collectionProductEntityToSync) {
+            $magentoCategoryId = $collectionProductEntityToSync['magento_category_id'];
+            $collectionProductEntityToSync['category_yotpo_id'] = $collectionsProductsCategoriesIdsToYotpoIdsMap[$magentoCategoryId] ?? null;
+
+            $magentoProductId = $collectionProductEntityToSync['magento_product_id'];
+            $collectionProductEntityToSync['product_yotpo_id'] = $collectionsProductsProductIdToYotpoIdsMap[$magentoProductId] ?? null;
+
+            $enrichedCollectionsProductsEntitiesToSync[] = $collectionProductEntityToSync;
+        }
+
+        return $enrichedCollectionsProductsEntitiesToSync;
+    }
+
+    /**
+     * @param array $enrichedCollectionsProductsEntitiesToSync
+     * @param string $storeId
+     * @return void
+     */
+    private function syncCollectionsProductsEntitiesToYotpo(array $enrichedCollectionsProductsEntitiesToSync, $storeId)
+    {
+        $requestEndpointKey = $this::COLLECTIONS_PRODUCT_ENDPOINT_STRING;
+        $collectionIdRequestParamString = $this::YOTPO_COLLECTION_ID_REQUEST_PARAM_STRING;
+
+        foreach ($enrichedCollectionsProductsEntitiesToSync as $enrichedCollectionProductEntityToSync) {
+            try {
+                $collectionYotpoId = $enrichedCollectionProductEntityToSync['category_yotpo_id'];
+                $productYotpoId = $enrichedCollectionProductEntityToSync['product_yotpo_id'];
+
+                if (!$collectionYotpoId) {
+                    $magentoCategoryId = $enrichedCollectionProductEntityToSync['magento_category_id'];
+                    $collectionYotpoId = $this->syncCollectionAndGetCreatedYotpoId($magentoCategoryId, $storeId);
+                    if ($collectionYotpoId == null) {
+                        $this->collectionsProductsService->updateCollectionsProductsSyncDataAsSyncedToYotpo($storeId, $enrichedCollectionProductEntityToSync);
+                        continue;
+                    }
+                }
+
+                if (!$productYotpoId) {
+                    $magentoProductId = $enrichedCollectionProductEntityToSync['magento_product_id'];
+                    $productYotpoId = $this->syncProductAndGetCreatedYotpoId($magentoProductId, $storeId);
+                    if ($productYotpoId == null) {
+                        $this->collectionsProductsService->updateCollectionsProductsSyncDataAsSyncedToYotpo($storeId, $enrichedCollectionProductEntityToSync);
+                        continue;
+                    }
+                }
+
+                $requestEndpoint = $this->coreConfig->getEndpoint($requestEndpointKey, [$collectionIdRequestParamString], [$collectionYotpoId]);
+                $collectionProductDataToSync = $this->prepareCollectionProductToSync($enrichedCollectionProductEntityToSync);
+                $collectionProductDataToSync['entityLog'] = $this::LOGGER_LOG_ENTITY_FILE;
+                $isCollectionProductDeletedInMagento = (bool)$enrichedCollectionProductEntityToSync['is_deleted_in_magento'];
+
+                $response = $this->syncCollectionProductToYotpo($requestEndpoint, $collectionProductDataToSync, $isCollectionProductDeletedInMagento);
+
+                if ($response->getData('is_success')) {
+                    $this->setAsSuccessfulCollectionProductSync($storeId, $enrichedCollectionProductEntityToSync);
+                } elseif ($this->isCollectionProductShouldBeSetAsSynced($response)) {
+                    $this->setAsSuccessfulCollectionProductSync($storeId, $enrichedCollectionProductEntityToSync);
+                }
+            } catch (Exception $exception) {
+                $this->catalogLogger->info(
+                    __(
+                        'Collections Products Sync - Failed syncing Collection Product entity to Yotpo - 
+                            Magento Store ID: %1,
+                            Magento Store Name: %2,
+                            Collection Yotpo ID: %3,
+                            Product Yotpo ID: %4,
+                            Exception: %5',
+                        $storeId,
+                        $this->coreConfig->getStoreName($storeId),
+                        $collectionYotpoId,
+                        $productYotpoId,
+                        $exception->getMessage()
+                    )
+                );
+                $this->setAsSuccessfulCollectionProductSync($storeId, $enrichedCollectionProductEntityToSync);
+            }
+        }
+    }
+
+    /**
+     * @param mixed $response
+     * @return bool
+     */
+    private function isCollectionProductShouldBeSetAsSynced($response)
+    {
+        $responseStatusCode = $response->getData('status');
+        $unsyncableCollectionProductStatusCodes = [ CoreConfig::CONFLICT_RESPONSE_CODE, CoreConfig::NOT_FOUND_RESPONSE_CODE ];
+        $isResyncableStatusCode = $this->coreConfig->canResync($responseStatusCode);
+
+        if (in_array($responseStatusCode, $unsyncableCollectionProductStatusCodes) || !$isResyncableStatusCode) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/Model/Sync/CollectionsProducts/Processor.php
+++ b/Model/Sync/CollectionsProducts/Processor.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Yotpo\Core\Model\Sync\CollectionsProducts;
+
+class Processor
+{
+    public function process()
+    {
+
+    }
+}

--- a/Model/Sync/CollectionsProducts/Services/CollectionsProductsService.php
+++ b/Model/Sync/CollectionsProducts/Services/CollectionsProductsService.php
@@ -201,6 +201,26 @@ class CollectionsProductsService extends AbstractJobs
         $this->insertOnDuplicate($this::YOTPO_COLLECTIONS_PRODUCTS_SYNC_TABLE_NAME, [$collectionsProductsSyncData]);
     }
 
+    /**
+     * @param string $storeId
+     * @param string $productId
+     * @return void
+     */
+    public function forceUpdateProductCollectionsForResync($storeId, $productId) {
+        $connection = $this->resourceConnection->getConnection();
+        $updateCondition = [
+            'magento_store_id = ?' => $storeId,
+            'magento_product_id = ?' => $productId,
+            'is_deleted_in_magento = ?' => 0
+        ];
+        $currentDatetime = date('Y-m-d H:i:s');
+        $connection->update(
+            $this->resourceConnection->getTableName($this::YOTPO_COLLECTIONS_PRODUCTS_SYNC_TABLE_NAME),
+            ['is_synced_to_yotpo' => 0, 'last_updated_at' => $currentDatetime],
+            $updateCondition
+        );
+    }
+
     private function isProductEligibleForProductsCollectionsSync($productId) {
         $parentProduct = $this->productTypeConfigurable->getParentIdsByChild($productId);
         if (!$parentProduct) {

--- a/Model/Sync/CollectionsProducts/Services/CollectionsProductsService.php
+++ b/Model/Sync/CollectionsProducts/Services/CollectionsProductsService.php
@@ -117,6 +117,31 @@ class CollectionsProductsService extends AbstractJobs
     }
 
     /**
+     * @param array $categoriesIds
+     * @param string $storeId
+     * @param string $productId
+     * @param boolean $isDeletedInMagento
+     * @return void
+     */
+    public function assignProductCategoriesForCollectionsProductsSync(array $categoriesIds, $storeId, $productId, $isDeletedInMagento = false)
+    {
+        $collectionsProductsSyncData = [];
+        $currentDatetime = date('Y-m-d H:i:s');
+        foreach ($categoriesIds as $categoryId) {
+            $collectionsProductsSyncData[] = [
+                'magento_store_id' => $storeId,
+                'magento_category_id' => $categoryId,
+                'magento_product_id' => $productId,
+                'is_deleted_in_magento' => $isDeletedInMagento,
+                'is_synced_to_yotpo' => false,
+                'last_updated_at' => $currentDatetime
+            ];
+        }
+
+        $this->insertOnDuplicate($this::YOTPO_COLLECTIONS_PRODUCTS_SYNC_TABLE_NAME, $collectionsProductsSyncData);
+    }
+
+    /**
      * @param string $storeId
      * @param array $collectionProductEntityToSync
      * @return void

--- a/Model/Sync/CollectionsProducts/Services/CollectionsProductsService.php
+++ b/Model/Sync/CollectionsProducts/Services/CollectionsProductsService.php
@@ -73,6 +73,50 @@ class CollectionsProductsService extends AbstractJobs
     }
 
     /**
+     * @param string $categoryId
+     * @return array<string>
+     */
+    public function getCategoryProductsIdsFromSyncTable($categoryId) {
+        $connection = $this->resourceConnection->getConnection();
+        $categoryProductsQuery = $connection->select(
+        )->from(
+            [ $this->resourceConnection->getTableName($this::YOTPO_COLLECTIONS_PRODUCTS_SYNC_TABLE_NAME) ],
+            [ 'magento_product_id' ]
+        )->where(
+            'magento_category_id = ?',
+            $categoryId
+        );
+
+        $categoryProductsIdsMap = $connection->fetchAssoc($categoryProductsQuery, 'magento_product_id');
+        return array_keys($categoryProductsIdsMap);
+    }
+
+    /**
+     * @param array $productsIds
+     * @param string $storeId
+     * @param string $categoryId
+     * @param boolean $isDeletedInMagento
+     * @return void
+     */
+    public function assignCategoryProductsForCollectionsProductsSync(array $productsIds, $storeId, $categoryId, $isDeletedInMagento = false)
+    {
+        $collectionsProductsSyncData = [];
+        $currentDatetime = date('Y-m-d H:i:s');
+        foreach ($productsIds as $productId) {
+            $collectionsProductsSyncData[] = [
+                'magento_store_id' => $storeId,
+                'magento_category_id' => $categoryId,
+                'magento_product_id' => $productId,
+                'is_deleted_in_magento' => $isDeletedInMagento,
+                'is_synced_to_yotpo' => false,
+                'last_updated_at' => $currentDatetime
+            ];
+        }
+
+        $this->insertOnDuplicate($this::YOTPO_COLLECTIONS_PRODUCTS_SYNC_TABLE_NAME, $collectionsProductsSyncData);
+    }
+
+    /**
      * @param string $storeId
      * @param array $collectionProductEntityToSync
      * @return void

--- a/Model/Sync/CollectionsProducts/Services/CollectionsProductsService.php
+++ b/Model/Sync/CollectionsProducts/Services/CollectionsProductsService.php
@@ -202,6 +202,29 @@ class CollectionsProductsService extends AbstractJobs
     }
 
     /**
+     * @param string $categoryId
+     * @return void
+     */
+    public function updateCollectionProductsSyncDataAsDeletedInYotpo($categoryId) {
+        $currentDatetime = date('Y-m-d H:i:s');
+        $connection = $this->resourceConnection->getConnection();
+        $updateCondition = [
+            'magento_category_id = ?' => $categoryId,
+            'is_deleted_in_magento = ?' => 0
+        ];
+        $dataToUpdate = [
+            'is_synced_to_yotpo' => 0,
+            'is_deleted_in_magento' => 1,
+            'last_updated_at' => $currentDatetime
+        ];
+        $connection->update(
+            $this->resourceConnection->getTableName($this::YOTPO_COLLECTIONS_PRODUCTS_SYNC_TABLE_NAME),
+            $dataToUpdate,
+            $updateCondition
+        );
+    }
+
+    /**
      * @param string $storeId
      * @param string $productId
      * @return void

--- a/Model/Sync/CollectionsProducts/Services/CollectionsProductsService.php
+++ b/Model/Sync/CollectionsProducts/Services/CollectionsProductsService.php
@@ -92,6 +92,25 @@ class CollectionsProductsService extends AbstractJobs
     }
 
     /**
+     * @param string $productId
+     * @return array<string>
+     */
+    public function getCategoryIdsFromSyncTableByProductId($productId) {
+        $connection = $this->resourceConnection->getConnection();
+        $categoryProductsQuery = $connection->select(
+        )->from(
+            [ $this->resourceConnection->getTableName($this::YOTPO_COLLECTIONS_PRODUCTS_SYNC_TABLE_NAME) ],
+            [ 'magento_category_id' ]
+        )->where(
+            'magento_product_id = ?',
+            $productId
+        );
+
+        $categoryProductsIdsMap = $connection->fetchAssoc($categoryProductsQuery, 'magento_category_id');
+        return array_keys($categoryProductsIdsMap);
+    }
+
+    /**
      * @param array $productsIds
      * @param string $storeId
      * @param string $categoryId

--- a/Model/Sync/CollectionsProducts/Services/CollectionsProductsService.php
+++ b/Model/Sync/CollectionsProducts/Services/CollectionsProductsService.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Yotpo\Core\Model\Sync\CollectionsProducts\Services;
+
+use Yotpo\Core\Model\AbstractJobs;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Store\Model\App\Emulation as AppEmulation;
+use Yotpo\Core\Model\Config as CoreConfig;
+use Yotpo\Core\Model\Sync\Catalog\YotpoResource;
+
+class CollectionsProductsService extends AbstractJobs
+{
+    const PRODUCT_SYNC_LIMIT_CONFIG_KEY = 'product_sync_limit';
+    const YOTPO_COLLECTIONS_PRODUCTS_SYNC_TABLE_NAME = 'yotpo_collections_products_sync';
+
+    /**
+     * @var CoreConfig
+     */
+    protected $coreConfig;
+
+    /**
+     * @var YotpoResource
+     */
+    protected $yotpoResource;
+
+    /**
+     * @var int
+     */
+    protected $collectionsProductsSyncBatchSize = null;
+
+    /**
+     * Processor constructor.
+     * @param AppEmulation $appEmulation
+     * @param ResourceConnection $resourceConnection
+     * @param CoreConfig $coreConfig
+     * @param YotpoResource $yotpoResource
+     **/
+    public function __construct(
+        AppEmulation $appEmulation,
+        ResourceConnection $resourceConnection,
+        CoreConfig $coreConfig,
+        YotpoResource $yotpoResource
+    ) {
+        $this->coreConfig = $coreConfig;
+        $this->yotpoResource = $yotpoResource;
+        $this->collectionsProductsSyncBatchSize = $this->coreConfig->getConfig($this::PRODUCT_SYNC_LIMIT_CONFIG_KEY);
+        parent::__construct($appEmulation, $resourceConnection);
+    }
+
+    /**
+     * @param integer $collectionsProductsSyncBatchSize
+     * @return array<string>
+     */
+    public function getCollectionsProductsToSync($collectionsProductsSyncBatchSize) {
+        $storeId = $this->coreConfig->getStoreId();
+        $connection = $this->resourceConnection->getConnection();
+        $categoryProductsQuery = $connection->select(
+        )->from(
+            [ $this->resourceConnection->getTableName($this::YOTPO_COLLECTIONS_PRODUCTS_SYNC_TABLE_NAME) ],
+            ['*']
+        )->where(
+            'magento_store_id = ?',
+            $storeId
+        )->where(
+            'is_synced_to_yotpo = ?',
+            false
+        )->limit(
+            $collectionsProductsSyncBatchSize
+        );
+
+        $collectionsProductsToSync = $connection->fetchAll($categoryProductsQuery);
+        return $collectionsProductsToSync;
+    }
+
+    /**
+     * @param string $storeId
+     * @param array $collectionProductEntityToSync
+     * @return void
+     */
+    public function updateCollectionsProductsSyncDataAsSyncedToYotpo($storeId, $collectionProductEntityToSync)
+    {
+        $currentDatetime = date('Y-m-d H:i:s');
+        $collectionsProductsSyncData = [
+            'magento_store_id' => $storeId,
+            'magento_category_id' => $collectionProductEntityToSync['magento_category_id'],
+            'magento_product_id' => $collectionProductEntityToSync['magento_product_id'],
+            'is_deleted_in_magento' => $collectionProductEntityToSync['is_deleted_in_magento'],
+            'is_synced_to_yotpo' => true,
+            'last_updated_at' => $currentDatetime
+        ];
+
+        $this->insertOnDuplicate($this::YOTPO_COLLECTIONS_PRODUCTS_SYNC_TABLE_NAME, [$collectionsProductsSyncData]);
+    }
+}

--- a/Observer/Category/DeleteAfter.php
+++ b/Observer/Category/DeleteAfter.php
@@ -6,6 +6,7 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\App\ResourceConnection;
 use Yotpo\Core\Model\Config;
+use Yotpo\Core\Model\Sync\CollectionsProducts\Services\CollectionsProductsService;
 
 /**
  * Class DeleteAfter - Update Yotpo Table
@@ -23,16 +24,23 @@ class DeleteAfter implements ObserverInterface
     private $config;
 
     /**
+     * @var CollectionsProductsService
+     */
+    private $collectionsProductsService;
+
+    /**
      * DeleteAfter constructor.
      * @param ResourceConnection $resourceConnection
      * @param Config $config
      */
     public function __construct(
         ResourceConnection $resourceConnection,
-        Config $config
+        Config $config,
+        CollectionsProductsService $collectionsProductsService
     ) {
         $this->resourceConnection = $resourceConnection;
         $this->config = $config;
+        $this->collectionsProductsService = $collectionsProductsService;
     }
 
     /**
@@ -43,16 +51,23 @@ class DeleteAfter implements ObserverInterface
      */
     public function execute(Observer $observer)
     {
-        $connection = $this->resourceConnection->getConnection();
-
         /** @var Category $category */
         $category = $observer->getEvent()->getData('category');
+        $categoryId = $category->getData('entity_id');
+        $this->assignCategoryForDeletion($categoryId);
+        $this->collectionsProductsService->updateCollectionProductsSyncDataAsDeletedInYotpo($categoryId);
+    }
+
+    /**
+     * @param string $categoryId
+     * @return void
+     */
+    private function assignCategoryForDeletion($categoryId) {
+        $connection = $this->resourceConnection->getConnection();
         $connection->update(
             $this->resourceConnection->getTableName('yotpo_category_sync'),
             ['is_deleted' => 1, 'is_deleted_at_yotpo' => 0, 'response_code' => Config::CUSTOM_RESPONSE_DATA],
-            [
-                'category_id = ?' => $category->getData('entity_id')
-            ]
+            ['category_id = ?' => $categoryId]
         );
     }
 }

--- a/Observer/Category/SaveBefore.php
+++ b/Observer/Category/SaveBefore.php
@@ -6,22 +6,20 @@ use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\App\ResourceConnection;
 use Yotpo\Core\Model\Config;
-use Yotpo\Core\Model\Sync\Data\Main;
+use Yotpo\Core\Model\Sync\Category\Processor\Main as CategoryProcessorMain;
+use Yotpo\Core\Model\Sync\CollectionsProducts\Services\CollectionsProductsService;
+use Yotpo\Core\Services\CatalogCategoryProductService;
 
 /**
  * Class SaveBefore - Update yotpo attribute
  */
 class SaveBefore implements ObserverInterface
 {
+
     /**
      * @var ResourceConnection
      */
     private $resourceConnection;
-
-    /**
-     * @var Main
-     */
-    private $main;
 
     /**
      * @var RequestInterface
@@ -34,70 +32,76 @@ class SaveBefore implements ObserverInterface
     protected $config;
 
     /**
+     * @var CategoryProcessorMain
+     */
+    protected $categoryProcessorMain;
+
+    /**
+     * @var CollectionsProductsService
+     */
+    protected $collectionsProductsService;
+
+    /**
+     * @var CatalogCategoryProductService
+     */
+    protected $catalogCategoryProductService;
+
+    /**
      * SaveBefore constructor.
      * @param ResourceConnection $resourceConnection
-     * @param Main $main
      * @param RequestInterface $request
+     * @param Config $config
+     * @param CategoryProcessorMain $categoryProcessorMain
+     * @param CollectionsProductsService $collectionsProductsService
+     * @param CatalogCategoryProductService $catalogCategoryProductService
      */
     public function __construct(
         ResourceConnection $resourceConnection,
-        Main $main,
         RequestInterface $request,
-        Config $config
+        Config $config,
+        CategoryProcessorMain $categoryProcessorMain,
+        CollectionsProductsService $collectionsProductsService,
+        CatalogCategoryProductService $catalogCategoryProductService
     ) {
         $this->resourceConnection = $resourceConnection;
-        $this->main = $main;
         $this->request = $request;
         $this->config = $config;
+        $this->categoryProcessorMain = $categoryProcessorMain;
+        $this->collectionsProductsService = $collectionsProductsService;
+        $this->catalogCategoryProductService = $catalogCategoryProductService;
     }
 
     /**
-     * Set synced_to_yotpo_collection = 0 in catalog_category_entity_int table
-     *
      * @param Observer $observer
      * @return void
      */
     public function execute(Observer $observer)
     {
-        $connection = $this->resourceConnection->getConnection();
-
-        $vmCategories = $this->request->getParam('vm_category_products');
-        $entityId = $this->request->getParam('entity_id');
-        $diffProducts = [];
-
-        if ($vmCategories && $entityId) {
-            $vmCategories = json_decode($vmCategories, true);
-
-            $select = $connection->select()->from(
-                ['e' => $this->resourceConnection->getTableName('catalog_category_product')],
-                ['product_id']
-            )->where(
-                'e.category_id =?',
-                $entityId
-            );
-            $categoryProducts = $connection->fetchAssoc($select, 'product_id');
-
-            $diffProducts = array_merge(
-                array_diff(array_keys($vmCategories), array_keys($categoryProducts)),
-                array_diff(array_keys($categoryProducts), array_keys($vmCategories))
-            );
-
-        } elseif ($vmCategories && !$entityId) {
-            $vmCategories = json_decode($vmCategories, true);
-            $diffProducts = array_keys($vmCategories);
+        $categoryId = $this->request->getParam('entity_id');
+        if (!$categoryId) {
+            return;
         }
 
-        if ($diffProducts) {
-            $cond = [
-                $this->config->getEavRowIdFieldName() . ' IN (?)' => $diffProducts,
-                'attribute_id = ? ' => $this->main->getAttributeId(Config::CATALOG_SYNC_ATTR_CODE)
-            ];
+        $currentProductIdsInCategory = $this->catalogCategoryProductService->getProductIdsFromCategoryProductsTableByCategoryId($categoryId);
+        $productIdToPositionInCategoryMapBeforeSave = json_decode($this->request->getParam('vm_category_products'), true);
+        $productIdsInCategoryBeforeSave = array_keys($productIdToPositionInCategoryMapBeforeSave);
 
-            $connection->update(
-                $this->resourceConnection->getTableName('catalog_product_entity_int'),
-                ['value' => 0],
-                $cond
-            );
+        $productsAddedToCategory = array_diff($productIdsInCategoryBeforeSave, $currentProductIdsInCategory);
+        $productsDeletedFromCategory = array_diff($currentProductIdsInCategory, $productIdsInCategoryBeforeSave);
+        $storeIdsSuccessfullySyncedWithCategory = $this->categoryProcessorMain->getStoresSuccessfullySyncedWithCategory($categoryId);
+
+        if ($storeIdsSuccessfullySyncedWithCategory) {
+            foreach ($storeIdsSuccessfullySyncedWithCategory as $storeId) {
+                if ($this->config->isCatalogSyncActive($storeId)) {
+                    if ($productsAddedToCategory) {
+                        $this->collectionsProductsService->assignCategoryProductsForCollectionsProductsSync($productsAddedToCategory, $storeId, $categoryId);
+                    }
+
+                    if ($productsDeletedFromCategory) {
+                        $this->collectionsProductsService->assignCategoryProductsForCollectionsProductsSync($productsDeletedFromCategory, $storeId, $categoryId, true);
+                    }
+                }
+            }
         }
     }
 }

--- a/Observer/Config/CronFrequency.php
+++ b/Observer/Config/CronFrequency.php
@@ -35,7 +35,7 @@ class CronFrequency
     protected $cronFrequency = [
         'catalog_sync_frequency' => [
             'config_path' => '',
-            'job_code' => 'yotpo_cron_core_products_sync,yotpo_cron_core_category_sync'
+            'job_code' => 'yotpo_cron_core_products_sync,yotpo_cron_core_category_sync,yotpo_cron_core_collections_products_sync'
         ],
         'orders_sync_frequency' => [
             'config_path' => '',

--- a/Observer/Product/Data.php
+++ b/Observer/Product/Data.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Yotpo\Core\Observer\Product;
+
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Store\Model\App\Emulation as AppEmulation;
+use Yotpo\Core\Model\AbstractJobs;
+
+/**
+ * Class Data - Product changes related data requests
+ */
+class Data extends AbstractJobs
+{
+
+    const CATALOG_CATEGORY_PRODUCT_TABLE = 'catalog_category_product';
+
+    /**
+     * @var AppEmulation
+     */
+    protected $appEmulation;
+
+    /**
+     * @var ResourceConnection
+     */
+    protected $resourceConnection;
+
+    /**
+     * Data constructor.
+     * @param ResourceConnection $resourceConnection
+     * @param AppEmulation $appEmulation
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        AppEmulation $appEmulation
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->appEmulation = $appEmulation;
+        parent::__construct($appEmulation, $resourceConnection);
+    }
+
+    /**
+     * @param string $productId
+     * @return array<string>
+     */
+    public function getCategoryIdsFromCategoryProductsTableByProductId($productId) {
+        $connection = $this->resourceConnection->getConnection();
+        $categoryProductsQuery = $connection->select(
+        )->from(
+            ['entity' => $this->resourceConnection->getTableName($this::CATALOG_CATEGORY_PRODUCT_TABLE)],
+            ['category_id']
+        )->where(
+            'product_id = ?',
+            $productId
+        );
+
+        $productCategoriesIdsMap = $connection->fetchAssoc($categoryProductsQuery, 'category_id');
+
+        $categoryIds = array_keys($productCategoriesIdsMap);
+        return $categoryIds;
+    }
+}

--- a/Observer/Product/DeleteAfter.php
+++ b/Observer/Product/DeleteAfter.php
@@ -45,10 +45,10 @@ class DeleteAfter implements ObserverInterface
     {
         $connection = $this->resourceConnection->getConnection();
         $product = $observer->getEvent()->getProduct();
-        $childIds = $this->catalogSession->getDeleteYotpoIds();
+        $productChildrenIdsForDeletion = $this->catalogSession->getDeleteYotpoIds();
 
-        if (isset($childIds[0])) {
-            $childIds = $childIds[0];
+        if (isset($productChildrenIdsForDeletion[0])) {
+            $productChildrenIdsForDeletion = $productChildrenIdsForDeletion[0];
         }
 
         $connection->update(
@@ -57,12 +57,12 @@ class DeleteAfter implements ObserverInterface
             $connection->quoteInto('product_id = ?', $product->getId())
         );
 
-        if ($childIds) {
-            $cond = [
-                'product_id IN (?) ' => $childIds,
+        if ($productChildrenIdsForDeletion) {
+            $condition = [
+                'product_id IN (?) ' => $productChildrenIdsForDeletion,
                 'yotpo_id != 0'
             ];
-            $data = [
+            $dataToUpdate = [
                 'yotpo_id_unassign' => new \Zend_Db_Expr('yotpo_id'),
                 'yotpo_id' => '0',
                 'response_code' => YotpoCoreConfig::CUSTOM_RESPONSE_DATA
@@ -70,8 +70,8 @@ class DeleteAfter implements ObserverInterface
 
             $connection->update(
                 $this->resourceConnection->getTableName('yotpo_product_sync'),
-                $data,
-                $cond
+                $dataToUpdate,
+                $condition
             );
         }
     }

--- a/Observer/Product/DeleteAfter.php
+++ b/Observer/Product/DeleteAfter.php
@@ -45,17 +45,27 @@ class DeleteAfter implements ObserverInterface
     {
         $connection = $this->resourceConnection->getConnection();
         $product = $observer->getEvent()->getProduct();
-        $productChildrenIdsForDeletion = $this->catalogSession->getDeleteYotpoIds();
-
-        if (isset($productChildrenIdsForDeletion[0])) {
-            $productChildrenIdsForDeletion = $productChildrenIdsForDeletion[0];
-        }
 
         $connection->update(
             $this->resourceConnection->getTableName('yotpo_product_sync'),
             ['is_deleted' => 1, 'is_deleted_at_yotpo' => 0, 'response_code' => YotpoCoreConfig::CUSTOM_RESPONSE_DATA],
             $connection->quoteInto('product_id = ?', $product->getId())
         );
+
+        $this->unassignProductChildrenForSync();
+    }
+
+    /**
+     * @return void
+     */
+    private function unassignProductChildrenForSync()
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $productChildrenIdsForDeletion = $this->catalogSession->getDeleteYotpoIds();
+
+        if (isset($productChildrenIdsForDeletion[0])) {
+            $productChildrenIdsForDeletion = $productChildrenIdsForDeletion[0];
+        }
 
         if ($productChildrenIdsForDeletion) {
             $condition = [

--- a/Observer/Product/DeleteAfter.php
+++ b/Observer/Product/DeleteAfter.php
@@ -4,7 +4,6 @@ namespace Yotpo\Core\Observer\Product;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer as EventObserver;
 use Magento\Framework\App\ResourceConnection;
-use Magento\Store\Model\App\Emulation as AppEmulation;
 use Magento\Catalog\Model\Session as CatalogSession;
 use Yotpo\Core\Model\Config as YotpoCoreConfig;
 use Yotpo\Core\Model\Sync\CollectionsProducts\Services\CollectionsProductsService;
@@ -13,13 +12,8 @@ use Yotpo\Core\Model\Sync\Category\Processor\Main as YotpoCategoryProcessorMain;
 /**
  * Class DeleteAfter - Update yotpo is_delete attribute
  */
-class DeleteAfter extends Data implements ObserverInterface
+class DeleteAfter implements ObserverInterface
 {
-    /**
-     * @var AppEmulation
-     */
-    protected $appEmulation;
-
     /**
      * @var ResourceConnection
      */
@@ -48,7 +42,6 @@ class DeleteAfter extends Data implements ObserverInterface
     /**
      * DeleteAfter constructor.
      * @param ResourceConnection $resourceConnection
-     * @param AppEmulation $appEmulation
      * @param CatalogSession $catalogSession
      * @param YotpoCoreConfig $yotpoCoreConfig
      * @param CollectionsProductsService $collectionsProductsService
@@ -56,7 +49,6 @@ class DeleteAfter extends Data implements ObserverInterface
      */
     public function __construct(
         ResourceConnection $resourceConnection,
-        AppEmulation $appEmulation,
         CatalogSession $catalogSession,
         YotpoCoreConfig $yotpoCoreConfig,
         CollectionsProductsService $collectionsProductsService,
@@ -67,7 +59,6 @@ class DeleteAfter extends Data implements ObserverInterface
         $this->yotpoCoreConfig = $yotpoCoreConfig;
         $this->collectionsProductsService = $collectionsProductsService;
         $this->yotpoCategoryProcessorMain = $yotpoCategoryProcessorMain;
-        parent::__construct($resourceConnection, $appEmulation);
     }
 
     /**

--- a/Observer/Product/DeleteBefore.php
+++ b/Observer/Product/DeleteBefore.php
@@ -3,20 +3,15 @@ namespace Yotpo\Core\Observer\Product;
 
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer as EventObserver;
-use Magento\Framework\App\ResourceConnection;
-use Magento\Store\Model\App\Emulation as AppEmulation;
 use Magento\Catalog\Model\Session as CatalogSession;
+use Magento\Framework\App\ResourceConnection;
+use Yotpo\Core\Services\CatalogCategoryProductService;
 
 /**
  * Class DeleteBefore - Update yotpo is_delete attribute
  */
-class DeleteBefore extends Data implements ObserverInterface
+class DeleteBefore implements ObserverInterface
 {
-    /**
-     * @var AppEmulation
-     */
-    protected $appEmulation;
-
     /**
      * @var ResourceConnection
      */
@@ -28,18 +23,24 @@ class DeleteBefore extends Data implements ObserverInterface
     protected $catalogSession;
 
     /**
+     * @var CatalogCategoryProductService
+     */
+    protected $catalogCategoryProductService;
+
+    /**
      * DeleteBefore constructor.
      * @param ResourceConnection $resourceConnection
-     * @param AppEmulation $appEmulation
      * @param CatalogSession $catalogSession
+     * @param CatalogCategoryProductService $catalogCategoryProductService
      */
     public function __construct(
         ResourceConnection $resourceConnection,
-        AppEmulation $appEmulation,
-        CatalogSession $catalogSession
+        CatalogSession $catalogSession,
+        CatalogCategoryProductService $catalogCategoryProductService
     ) {
+        $this->resourceConnection = $resourceConnection;
         $this->catalogSession = $catalogSession;
-        parent::__construct($resourceConnection, $appEmulation);
+        $this->catalogCategoryProductService = $catalogCategoryProductService;
     }
 
     /**
@@ -56,7 +57,7 @@ class DeleteBefore extends Data implements ObserverInterface
             $productId = $product->getId();
             $childrenIds = $product->getTypeInstance()->getChildrenIds($productId);
             $this->catalogSession->setDeleteYotpoIds($childrenIds);
-            $productCategoriesIds = $this->getCategoryIdsFromCategoryProductsTableByProductId($productId);
+            $productCategoriesIds = $this->catalogCategoryProductService->getCategoryIdsFromCategoryProductsTableByProductId($productId);
             $this->catalogSession->setProductCategoriesIds($productCategoriesIds);
         }
     }

--- a/Observer/Product/DeleteBefore.php
+++ b/Observer/Product/DeleteBefore.php
@@ -3,13 +3,25 @@ namespace Yotpo\Core\Observer\Product;
 
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer as EventObserver;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Store\Model\App\Emulation as AppEmulation;
 use Magento\Catalog\Model\Session as CatalogSession;
 
 /**
  * Class DeleteBefore - Update yotpo is_delete attribute
  */
-class DeleteBefore implements ObserverInterface
+class DeleteBefore extends Data implements ObserverInterface
 {
+    /**
+     * @var AppEmulation
+     */
+    protected $appEmulation;
+
+    /**
+     * @var ResourceConnection
+     */
+    protected $resourceConnection;
+
     /**
      * @var CatalogSession
      */
@@ -17,12 +29,17 @@ class DeleteBefore implements ObserverInterface
 
     /**
      * DeleteBefore constructor.
+     * @param ResourceConnection $resourceConnection
+     * @param AppEmulation $appEmulation
      * @param CatalogSession $catalogSession
      */
     public function __construct(
+        ResourceConnection $resourceConnection,
+        AppEmulation $appEmulation,
         CatalogSession $catalogSession
     ) {
         $this->catalogSession = $catalogSession;
+        parent::__construct($resourceConnection, $appEmulation);
     }
 
     /**
@@ -36,8 +53,11 @@ class DeleteBefore implements ObserverInterface
         $product = $observer->getEvent()->getProduct();
 
         if ($product->hasDataChanges()) {
-            $childrenIds = $product->getTypeInstance()->getChildrenIds($product->getId());
+            $productId = $product->getId();
+            $childrenIds = $product->getTypeInstance()->getChildrenIds($productId);
             $this->catalogSession->setDeleteYotpoIds($childrenIds);
+            $productCategoriesIds = $this->getCategoryIdsFromCategoryProductsTableByProductId($productId);
+            $this->catalogSession->setProductCategoriesIds($productCategoriesIds);
         }
     }
 }

--- a/Observer/Product/SaveAfter.php
+++ b/Observer/Product/SaveAfter.php
@@ -139,7 +139,7 @@ class SaveAfter implements ObserverInterface
         $existingIds = $product->getOrigData('website_ids');
         $newIds = $product->getData('website_ids');
 
-        $removedWebsite = $this->findDifferentArray($existingIds, $newIds);
+        $removedWebsite = $this->findAndRetrieveDifferenceBetweenArrays($existingIds, $newIds);
         if (count($removedWebsite) > 0) {
             $storeIds = $this->collectStoreIds($removedWebsite);
             $tableData = [
@@ -150,7 +150,7 @@ class SaveAfter implements ObserverInterface
             $this->updateYotpoSyncTable($tableData, $storeIds, [$product->getId()]);
         }
 
-        $newWebsite = $this->findDifferentArray($newIds, $existingIds);
+        $newWebsite = $this->findAndRetrieveDifferenceBetweenArrays($newIds, $existingIds);
         if (count($newWebsite) > 0) {
             $storeIds = $this->collectStoreIds($newWebsite);
 
@@ -205,7 +205,7 @@ class SaveAfter implements ObserverInterface
             $this->updateUnAssign($result, $product);
         }
 
-        $result = $this->findDifferentArray($productChildrenIds, $productChildrenIdsBeforeSave);
+        $result = $this->findAndRetrieveDifferenceBetweenArrays($productChildrenIds, $productChildrenIdsBeforeSave);
         if (count($result) > 0) {
             $this->updateProductAttribute($result, [$product->getStoreId()]);
             $tableData = ['response_code' => Config::CUSTOM_RESPONSE_DATA];
@@ -240,20 +240,6 @@ class SaveAfter implements ObserverInterface
             $data,
             $cond
         );
-    }
-
-    /**
-     * @param array<int, int>|int $firstArray
-     * @param array<int, int>|int $secondArray
-     * @return array<int, int>
-     */
-    public function findDifferentArray($firstArray, $secondArray)
-    {
-        $result = [];
-        if (is_array($firstArray) && is_array($secondArray)) {
-            $result = array_diff($firstArray, $secondArray);
-        }
-        return $result;
     }
 
     /**
@@ -311,5 +297,20 @@ class SaveAfter implements ObserverInterface
         $productChildrenIds = $product->getTypeInstance()->getChildrenIds($product->getId());
         $this->manageUnAssign($productChildrenIdsBeforeSave, $productChildrenIds, $product);
         $this->catalogSession->unsChildrenIds();
+    }
+
+    /**
+     * @param array<int, int>|int $firstArray
+     * @param array<int, int>|int $secondArray
+     * @return array<int, int>
+     */
+    private function findAndRetrieveDifferenceBetweenArrays($firstArray, $secondArray)
+    {
+        $result = [];
+        if (is_array($firstArray) && is_array($secondArray)) {
+            $result = array_diff($firstArray, $secondArray);
+        }
+
+        return $result;
     }
 }

--- a/Observer/Product/SaveAfter.php
+++ b/Observer/Product/SaveAfter.php
@@ -81,21 +81,23 @@ class SaveAfter implements ObserverInterface
      */
     public function execute(EventObserver $observer)
     {
-        $storeIds = [];
+        $storeIdsToUpdate = [];
         $product = $observer->getEvent()->getProduct();
         $currentStoreId = $product->getStoreId();
         if ($currentStoreId == 0) {
             $stores = $this->storeRepository->getList();
             foreach ($stores as $store) {
-                $storeIds[] = $store->getId();
+                $storeIdsToUpdate[] = $store->getId();
             }
+        } else {
+            $storeIdsToUpdate[] = $currentStoreId;
         }
-        $storeIdsToUpdate  = $currentStoreId == 0 ? $storeIds : [$product->getStoreId()];
+
         if ($product->hasDataChanges()) {
             $this->updateProductAttribute([$product->getRowId() ?: $product->getId()], $storeIdsToUpdate);
             $this->updateIsDeleted($product);
             $tableData = ['response_code' => Config::CUSTOM_RESPONSE_DATA];
-            $this->updateYotpoSyncTable($tableData, $storeIds, [$product->getId()]);
+            $this->updateYotpoSyncTable($tableData, $storeIdsToUpdate, [$product->getId()]);
         }
 
         $oldChildIds = $this->catalogSession->getChildrenIds();

--- a/Observer/Product/SaveAfter.php
+++ b/Observer/Product/SaveAfter.php
@@ -3,11 +3,13 @@ namespace Yotpo\Core\Observer\Product;
 
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer as EventObserver;
+use Magento\Store\Model\App\Emulation as AppEmulation;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Store\Model\StoreManagerInterface;
 use Magento\Framework\App\ResourceConnection;
 use Yotpo\Core\Model\Config;
 use Yotpo\Core\Model\Sync\Data\Main;
+use Yotpo\Core\Model\Sync\CollectionsProducts\Services\CollectionsProductsService;
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\Session as CatalogSession;
 use Magento\Store\Api\StoreRepositoryInterface;
@@ -15,7 +17,7 @@ use Magento\Store\Api\StoreRepositoryInterface;
 /**
  * Class SaveAfter - Update yotpo attribute value when product updated
  */
-class SaveAfter implements ObserverInterface
+class SaveAfter extends Data implements ObserverInterface
 {
     /**
      * @var StoreManagerInterface
@@ -23,9 +25,14 @@ class SaveAfter implements ObserverInterface
     protected $storeManager;
 
     /**
-     * @var ResourceConnection
+     * @var AppEmulation
      */
     protected $resourceConnection;
+
+    /**
+     * @var ResourceConnection
+     */
+    protected $appEmulation;
 
     /**
      * @var Main
@@ -48,28 +55,40 @@ class SaveAfter implements ObserverInterface
     protected $config;
 
     /**
+     * @var CollectionsProductsService
+     */
+    protected $collectionsProductsService;
+
+    /**
      * SaveAfter constructor.
      * @param StoreManagerInterface $storeManager
      * @param ResourceConnection $resourceConnection
+     * @param AppEmulation $appEmulation
      * @param Main $main
      * @param CatalogSession $catalogSession
      * @param StoreRepositoryInterface $storeRepository
      * @param Config $config
+     * @param CollectionsProductsService $collectionsProductsService
      */
     public function __construct(
         StoreManagerInterface $storeManager,
         ResourceConnection $resourceConnection,
+        AppEmulation $appEmulation,
         Main $main,
         CatalogSession $catalogSession,
         StoreRepositoryInterface $storeRepository,
-        Config $config
+        Config $config,
+        CollectionsProductsService $collectionsProductsService
     ) {
         $this->storeManager = $storeManager;
         $this->resourceConnection = $resourceConnection;
+        $this->appEmulation = $appEmulation;
         $this->main = $main;
         $this->catalogSession = $catalogSession;
         $this->storeRepository = $storeRepository;
         $this->config = $config;
+        $this->collectionsProductsService = $collectionsProductsService;
+        parent::__construct($resourceConnection, $appEmulation);
     }
 
     /**
@@ -102,6 +121,18 @@ class SaveAfter implements ObserverInterface
         }
 
         $this->unassignProductChildrensForSync($product);
+
+        $productCategoriesBeforeSave = $this->catalogSession->getProductCategoriesIds();
+        $productCategories = $this->getCategoryIdsFromCategoryProductsTableByProductId($productId);
+        foreach($storeIdsToUpdate as $storeId) {
+            if (!$this->config->isCatalogSyncActive($storeId)) {
+                continue;
+            }
+
+            $this->assignProductCategoriesForCollectionsProductsSync($productCategoriesBeforeSave, $productCategories, $storeId, $productId);
+            $this->assignDeletedProductCategoriesForCollectionsProductsSync($productCategoriesBeforeSave, $productCategories, $storeId, $productId);
+        }
+
     }
 
     /**
@@ -297,6 +328,32 @@ class SaveAfter implements ObserverInterface
         $productChildrenIds = $product->getTypeInstance()->getChildrenIds($product->getId());
         $this->manageUnAssign($productChildrenIdsBeforeSave, $productChildrenIds, $product);
         $this->catalogSession->unsChildrenIds();
+    }
+
+    /**
+     * @param array $productCategoriesBeforeSave
+     * @param array $productCategories
+     * @param string $storeId
+     * @param string $productId
+     * @return void
+     */
+    private function assignProductCategoriesForCollectionsProductsSync($productCategoriesBeforeSave, $productCategories, $storeId, $productId)
+    {
+        $categoriesIdsForSync = $this->findAndRetrieveDifferenceBetweenArrays($productCategories, $productCategoriesBeforeSave);
+        $this->collectionsProductsService->assignProductCategoriesForCollectionsProductsSync($categoriesIdsForSync, $storeId, $productId);
+    }
+
+    /**
+     * @param array $productCategoriesBeforeSave
+     * @param array $productCategories
+     * @param string $storeId
+     * @param string $productId
+     * @return void
+     */
+    private function assignDeletedProductCategoriesForCollectionsProductsSync($productCategoriesBeforeSave, $productCategories, $storeId, $productId)
+    {
+        $categoriesIdsForSync = $this->findAndRetrieveDifferenceBetweenArrays($productCategoriesBeforeSave, $productCategories);
+        $this->collectionsProductsService->assignProductCategoriesForCollectionsProductsSync($categoriesIdsForSync, $storeId, $productId, true);
     }
 
     /**

--- a/Observer/Product/SaveAfter.php
+++ b/Observer/Product/SaveAfter.php
@@ -100,9 +100,9 @@ class SaveAfter implements ObserverInterface
             $this->updateYotpoSyncTable($tableData, $storeIdsToUpdate, [$product->getId()]);
         }
 
-        $oldChildIds = $this->catalogSession->getChildrenIds();
-        $newChildIds = $product->getTypeInstance()->getChildrenIds($product->getId());
-        $this->manageUnAssign($oldChildIds, $newChildIds, $product);
+        $productChildrenIdsBeforeSave = $this->catalogSession->getChildrenIds();
+        $productChildrenIds = $product->getTypeInstance()->getChildrenIds($product->getId());
+        $this->manageUnAssign($productChildrenIdsBeforeSave, $productChildrenIds, $product);
         $this->catalogSession->unsChildrenIds();
     }
 
@@ -185,29 +185,29 @@ class SaveAfter implements ObserverInterface
     }
 
     /**
-     * @param array<int, int> $oldChild
-     * @param array<int, int> $newChild
+     * @param array<int, int> $productChildrenIdsBeforeSave
+     * @param array<int, int> $productChildrenIds
      * @param Product $product
      * @return void
      */
-    protected function manageUnAssign($oldChild, $newChild, $product)
+    protected function manageUnAssign($productChildrenIdsBeforeSave, $productChildrenIds, $product)
     {
-        if (isset($oldChild[0])) {
-            $oldChild = (array)$oldChild[0];
+        if (isset($productChildrenIdsBeforeSave[0])) {
+            $productChildrenIdsBeforeSave = (array)$productChildrenIdsBeforeSave[0];
         }
-        if (isset($newChild[0])) {
-            $newChild = (array)$newChild[0];
+        if (isset($productChildrenIds[0])) {
+            $productChildrenIds = (array)$productChildrenIds[0];
         }
 
-        $oldChild = $this->checkIfMultiDimensional($oldChild);
-        $newChild = $this->checkIfMultiDimensional($newChild);
+        $productChildrenIdsBeforeSave = $this->checkIfMultiDimensional($productChildrenIdsBeforeSave);
+        $productChildrenIds = $this->checkIfMultiDimensional($productChildrenIds);
 
-        $result = array_merge(array_diff($oldChild, $newChild), array_diff($newChild, $oldChild));
+        $result = array_merge(array_diff($productChildrenIdsBeforeSave, $productChildrenIds), array_diff($productChildrenIds, $productChildrenIdsBeforeSave));
         if (count($result) > 0) {
             $this->updateUnAssign($result, $product);
         }
 
-        $result = $this->findDifferentArray($newChild, $oldChild);
+        $result = $this->findDifferentArray($productChildrenIds, $productChildrenIdsBeforeSave);
         if (count($result) > 0) {
             $this->updateProductAttribute($result, [$product->getStoreId()]);
             $tableData = ['response_code' => Config::CUSTOM_RESPONSE_DATA];

--- a/Observer/Product/SaveAfter.php
+++ b/Observer/Product/SaveAfter.php
@@ -93,11 +93,12 @@ class SaveAfter implements ObserverInterface
             $storeIdsToUpdate[] = $currentStoreId;
         }
 
+        $productId = $product->getId();
         if ($product->hasDataChanges()) {
-            $this->updateProductAttribute([$product->getRowId() ?: $product->getId()], $storeIdsToUpdate);
+            $this->updateProductAttribute([$product->getRowId() ?: $productId], $storeIdsToUpdate);
             $this->updateIsDeleted($product);
             $tableData = ['response_code' => Config::CUSTOM_RESPONSE_DATA];
-            $this->updateYotpoSyncTable($tableData, $storeIdsToUpdate, [$product->getId()]);
+            $this->updateYotpoSyncTable($tableData, $storeIdsToUpdate, [$productId]);
         }
 
         $this->unassignProductChildrensForSync($product);

--- a/Observer/Product/SaveAfter.php
+++ b/Observer/Product/SaveAfter.php
@@ -100,10 +100,7 @@ class SaveAfter implements ObserverInterface
             $this->updateYotpoSyncTable($tableData, $storeIdsToUpdate, [$product->getId()]);
         }
 
-        $productChildrenIdsBeforeSave = $this->catalogSession->getChildrenIds();
-        $productChildrenIds = $product->getTypeInstance()->getChildrenIds($product->getId());
-        $this->manageUnAssign($productChildrenIdsBeforeSave, $productChildrenIds, $product);
-        $this->catalogSession->unsChildrenIds();
+        $this->unassignProductChildrensForSync($product);
     }
 
     /**
@@ -301,5 +298,17 @@ class SaveAfter implements ObserverInterface
         }
 
         return $returnArray;
+    }
+
+    /**
+     * @param $product
+     * @return void
+     */
+    private function unassignProductChildrensForSync($product)
+    {
+        $productChildrenIdsBeforeSave = $this->catalogSession->getChildrenIds();
+        $productChildrenIds = $product->getTypeInstance()->getChildrenIds($product->getId());
+        $this->manageUnAssign($productChildrenIdsBeforeSave, $productChildrenIds, $product);
+        $this->catalogSession->unsChildrenIds();
     }
 }

--- a/Observer/Product/SaveBefore.php
+++ b/Observer/Product/SaveBefore.php
@@ -3,13 +3,26 @@ namespace Yotpo\Core\Observer\Product;
 
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer as EventObserver;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Store\Model\App\Emulation as AppEmulation;
 use Magento\Catalog\Model\Session as CatalogSession;
 
 /**
  * Class SaveBefore - Save childIds in session
  */
-class SaveBefore implements ObserverInterface
+class SaveBefore extends Data implements ObserverInterface
 {
+
+    /**
+     * @var AppEmulation
+     */
+    protected $appEmulation;
+
+    /**
+     * @var ResourceConnection
+     */
+    protected $resourceConnection;
+
     /**
      * @var CatalogSession
      */
@@ -17,12 +30,17 @@ class SaveBefore implements ObserverInterface
 
     /**
      * SaveBefore constructor.
+     * @param ResourceConnection $resourceConnection
+     * @param AppEmulation $appEmulation
      * @param CatalogSession $catalogSession
      */
     public function __construct(
+        ResourceConnection $resourceConnection,
+        AppEmulation $appEmulation,
         CatalogSession $catalogSession
     ) {
         $this->catalogSession = $catalogSession;
+        parent::__construct($resourceConnection, $appEmulation);
     }
 
     /**
@@ -36,8 +54,11 @@ class SaveBefore implements ObserverInterface
         $product = $observer->getEvent()->getProduct();
 
         if ($product->hasDataChanges()) {
-            $childrenIds = $product->getTypeInstance()->getChildrenIds($product->getId());
+            $productId = $product->getId();
+            $childrenIds = $product->getTypeInstance()->getChildrenIds($productId);
             $this->catalogSession->setChildrenIds($childrenIds);
+            $productCategoriesIds = $this->getCategoryIdsFromCategoryProductsTableByProductId($productId);
+            $this->catalogSession->setProductCategoriesIds($productCategoriesIds);
         }
     }
 }

--- a/Observer/Product/SaveBefore.php
+++ b/Observer/Product/SaveBefore.php
@@ -3,21 +3,15 @@ namespace Yotpo\Core\Observer\Product;
 
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer as EventObserver;
-use Magento\Framework\App\ResourceConnection;
-use Magento\Store\Model\App\Emulation as AppEmulation;
 use Magento\Catalog\Model\Session as CatalogSession;
+use Magento\Framework\App\ResourceConnection;
+use Yotpo\Core\Services\CatalogCategoryProductService;
 
 /**
  * Class SaveBefore - Save childIds in session
  */
-class SaveBefore extends Data implements ObserverInterface
+class SaveBefore implements ObserverInterface
 {
-
-    /**
-     * @var AppEmulation
-     */
-    protected $appEmulation;
-
     /**
      * @var ResourceConnection
      */
@@ -29,18 +23,24 @@ class SaveBefore extends Data implements ObserverInterface
     protected $catalogSession;
 
     /**
+     * @var CatalogCategoryProductService
+     */
+    protected $catalogCategoryProductService;
+
+    /**
      * SaveBefore constructor.
      * @param ResourceConnection $resourceConnection
-     * @param AppEmulation $appEmulation
      * @param CatalogSession $catalogSession
+     * @param CatalogCategoryProductService $catalogCategoryProductService
      */
     public function __construct(
         ResourceConnection $resourceConnection,
-        AppEmulation $appEmulation,
-        CatalogSession $catalogSession
+        CatalogSession $catalogSession,
+        CatalogCategoryProductService $catalogCategoryProductService
     ) {
+        $this->resourceConnection = $resourceConnection;
         $this->catalogSession = $catalogSession;
-        parent::__construct($resourceConnection, $appEmulation);
+        $this->catalogCategoryProductService = $catalogCategoryProductService;
     }
 
     /**
@@ -57,7 +57,7 @@ class SaveBefore extends Data implements ObserverInterface
             $productId = $product->getId();
             $childrenIds = $product->getTypeInstance()->getChildrenIds($productId);
             $this->catalogSession->setChildrenIds($childrenIds);
-            $productCategoriesIds = $this->getCategoryIdsFromCategoryProductsTableByProductId($productId);
+            $productCategoriesIds = $this->catalogCategoryProductService->getCategoryIdsFromCategoryProductsTableByProductId($productId);
             $this->catalogSession->setProductCategoriesIds($productCategoriesIds);
         }
     }

--- a/Services/CatalogCategoryProductService.php
+++ b/Services/CatalogCategoryProductService.php
@@ -1,16 +1,15 @@
 <?php
 
-namespace Yotpo\Core\Observer\Product;
+namespace Yotpo\Core\Services;
 
-use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Store\Model\App\Emulation as AppEmulation;
 use Yotpo\Core\Model\AbstractJobs;
 
 /**
- * Class Data - Product changes related data requests
+ * Class CatalogCategoryProductService - Used for read operations on catalog_category_product table
  */
-class Data extends AbstractJobs
+class CatalogCategoryProductService extends AbstractJobs
 {
 
     const CATALOG_CATEGORY_PRODUCT_TABLE = 'catalog_category_product';
@@ -43,20 +42,18 @@ class Data extends AbstractJobs
      * @param string $productId
      * @return array<string>
      */
-    public function getCategoryIdsFromCategoryProductsTableByProductId($productId) {
+    public function getCategoryIdsFromCategoryProductsTableByProductId($productId)
+    {
         $connection = $this->resourceConnection->getConnection();
-        $categoryProductsQuery = $connection->select(
-        )->from(
-            ['entity' => $this->resourceConnection->getTableName($this::CATALOG_CATEGORY_PRODUCT_TABLE)],
-            ['category_id']
+        $categoryProductsQuery = $connection->select()->from(
+            [ $this->resourceConnection->getTableName($this::CATALOG_CATEGORY_PRODUCT_TABLE) ],
+            [ 'category_id' ]
         )->where(
             'product_id = ?',
             $productId
         );
 
         $productCategoriesIdsMap = $connection->fetchAssoc($categoryProductsQuery, 'category_id');
-
-        $categoryIds = array_keys($productCategoriesIdsMap);
-        return $categoryIds;
+        return array_keys($productCategoriesIdsMap);
     }
 }

--- a/Services/CatalogCategoryProductService.php
+++ b/Services/CatalogCategoryProductService.php
@@ -56,4 +56,22 @@ class CatalogCategoryProductService extends AbstractJobs
         $productCategoriesIdsMap = $connection->fetchAssoc($categoryProductsQuery, 'category_id');
         return array_keys($productCategoriesIdsMap);
     }
+
+    /**
+     * @param string $categoryId
+     * @return array<string>
+     */
+    public function getProductIdsFromCategoryProductsTableByCategoryId($categoryId) {
+        $connection = $this->resourceConnection->getConnection();
+        $select = $connection->select()->from(
+            $this->resourceConnection->getTableName($this::CATALOG_CATEGORY_PRODUCT_TABLE),
+            [ 'product_id' ]
+        )->where(
+            'category_id = ?',
+            $categoryId
+        );
+
+        $currentProductsInCategory = $connection->fetchAssoc($select, 'product_id');
+        return array_keys($currentProductsInCategory);
+    }
 }

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -78,6 +78,11 @@
                             <cron_expr>*/2 * * * *</cron_expr>
                         </schedule>
                     </yotpo_cron_core_category_sync>
+                    <yotpo_cron_core_collections_products_sync>
+                        <schedule>
+                            <cron_expr>*/2 * * * *</cron_expr>
+                        </schedule>
+                    </yotpo_cron_core_collections_products_sync>
                 </jobs>
             </yotpo_core_catalog_sync>
         </crontab>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -12,6 +12,9 @@
         <job name="yotpo_cron_core_category_sync" instance="Yotpo\Core\Model\Sync\Catalog\Cron\CategorySync" method="execute">
             <config_path>crontab/yotpo_core_catalog_sync/jobs/yotpo_cron_core_category_sync/schedule/cron_expr</config_path>
         </job>
+        <job name="yotpo_cron_core_collections_products_sync" instance="Yotpo\Core\Model\Sync\CollectionsProducts\Cron\CollectionsProductsSync" method="execute">
+            <config_path>crontab/yotpo_core_catalog_sync/jobs/yotpo_cron_core_collections_products_sync/schedule/cron_expr</config_path>
+        </job>
     </group>
     <group id="yotpo_misc">
         <job name="yotpo_cron_core_metadata_sync" instance="Yotpo\Core\Model\Sync\Metadata\Cron\MetadataSync" method="execute">

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -89,4 +89,33 @@
             <column name="entity_id"/>
         </index>
     </table>
+    <table name="yotpo_collections_products_sync" resource="default" engine="innodb" comment="Collections products sync to Yotpo">
+        <column xsi:type="int" name="entity_id" unsigned="true" nullable="false" identity="true" comment="Entity ID"/>
+        <column xsi:type="int" name="magento_store_id" unsigned="true" nullable="false" default="0" comment="Magento Store ID"/>/>
+        <column xsi:type="int" name="magento_category_id" unsigned="true" nullable="false" comment="Magento Category ID"/>
+        <column xsi:type="int" name="magento_product_id" unsigned="true" nullable="false" comment="Magento Product ID"/>
+        <column xsi:type="boolean" name="is_deleted_in_magento" nullable="false" comment="Is Deleted in Magento"/>
+        <column xsi:type="boolean" name="is_synced_to_yotpo" nullable="false" comment="Is Synced to Yotpo"/>
+        <column xsi:type="datetime" name="last_updated_at" nullable="false" comment="Last Updated at Time"/>
+        <constraint xsi:type="primary" referenceId="PRIMARY">
+            <column name="entity_id"/>
+        </constraint>
+        <constraint xsi:type="unique" referenceId="YOTPO_COLLECTIONS_PRODUCTS_SYNC_UNIQUE_KEY_MAGENTO_STORE_ID_MAGENTO_CATEGORY_ID_MAGENTO_PRODUCT_ID">
+            <column name="magento_store_id"/>
+            <column name="magento_category_id"/>
+            <column name="magento_product_id"/>
+        </constraint>
+        <index referenceId="MAGENTO_STORE_ID_ON_IS_SYNCED_TO_YOTPO" indexType="btree">
+            <column name="magento_store_id"/>
+            <column name="is_synced_to_yotpo"/>
+        </index>
+        <index referenceId="MAGENTO_STORE_ID_ON_MAGENTO_CATEGORY_ID" indexType="btree">
+            <column name="magento_store_id"/>
+            <column name="magento_category_id"/>
+        </index>
+        <index referenceId="MAGENTO_STORE_ID_ON_MAGENTO_PRODUCT_ID" indexType="btree">
+            <column name="magento_store_id"/>
+            <column name="magento_product_id"/>
+        </index>
+    </table>
 </schema>

--- a/etc/db_schema_whitelist.json
+++ b/etc/db_schema_whitelist.json
@@ -64,5 +64,24 @@
             "PRIMARY": true,
             "YOTPO_CATEGORY_SYNC_CATEGORY_ID_STORE_ID": true
         }
+    },
+    "yotpo_collections_products_sync": {
+        "column": {
+            "magento_store_id": true,
+            "magento_category_id": true,
+            "magento_product_id": true,
+            "is_synced_to_yotpo": true,
+            "is_deleted_in_magento": true,
+            "last_updated_at": true
+        },
+        "index": {
+            "MAGENTO_STORE_ID_ON_IS_SYNCED_TO_YOTPO": true,
+            "MAGENTO_STORE_ID_ON_MAGENTO_CATEGORY_ID": true,
+            "MAGENTO_STORE_ID_ON_MAGENTO_PRODUCT_ID": true
+        },
+        "constraint": {
+            "PRIMARY": true,
+            "YOTPO_COLLECTIONS_PRODUCTS_SYNC_MAGENTO_STORE_ID_MAGENTO_CATEGORY_ID_MAGENTO_PRODUCT_ID": true
+        }
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -89,6 +89,8 @@
                 type="Yotpo\Core\Model\CategorySyncRepository" />
     <preference for="Yotpo\Core\Api\ProductSyncRepositoryInterface"
                 type="Yotpo\Core\Model\ProductSyncRepository" />
+    <preference for="Yotpo\Core\Api\CollectionsProductsSyncRepositoryInterface"
+                type="Yotpo\Core\Model\CollectionsProductsSyncRepository" />
     <type name="Magento\Framework\Console\CommandList">
         <arguments>
             <argument name="commands" xsi:type="array">


### PR DESCRIPTION
## Description
The category products sync was based on performing GET requests to Yotpo in order for the sync process to identify which category <> product relations were already synced to Yotpo.
This is a highly inefficient and un-scaleable method, which was poorly performing during our QA and tests.

Additionally, the existing solution supports syncing up to 100 collections per product due to the GET requests not supporting paginations.
Suggestions to add pagination support in order to resolve this limitation might lead the extension to consume extensive amounts of memory.

## Solution
In this PR, we're creating a new logic for syncing category products.
It includes a creation of a new sync table (`yotpo_collections_products_sync`) and a new cron.
The new cron is handling addition/creation of category products to the Yotpo API.
Addition or deletion is marked in the new sync table by the product and category process - both by observers and cron processes.

**Cases that were taken into consideration:**
* New category is created
* An existing category is deleted
* New Product is created
* An existing product is deleted
* Product is added to a collection via the product configuration page
* Product is deleted from a collection via the product configuration page
* Products are added to an existing category via the category configuration page (EE feature)
* Products are deleted from an existing category via the category configuration page (EE feature)
* The Yotpo ID of a product changes
* The Yotpo ID of a category changes 

Further than that, this PR also includes some extensive refactoring to the category syncing process.