### PR TITLE
COR-FIX sync issues on partial items

### DIFF
--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -217,14 +217,14 @@ class Data extends Main
             $syncItems[$entityId] = $this->attributeMapping($item);
         }
         $visibleVariantsData = [];
-        $parentIds = [];
+        $productIdsToParentIdsMap = [];
         if (!$isVariantsDataIncluded) {
-            $configIdsToCheck = $this->yotpoResource->getConfigProductIds($productsId);
-            $configIds = $this->filterNotConfigurableProducts($configIdsToCheck);
-            $syncItems = $this->mergeProductOptions($syncItems, $configIds, $productsObject);
-            $groupIds = $this->yotpoResource->getGroupProductIds($productsId);
-            $parentIds = $configIds + $groupIds;
-            foreach ($parentIds as $simpleId => $parentId) {
+            $productIdsToConfigurableIdsMapToCheck = $this->yotpoResource->getConfigProductIds($productsId);
+            $productIdsToConfigurableIdsMap = $this->filterNotConfigurableProducts($productIdsToConfigurableIdsMapToCheck);
+            $syncItems = $this->mergeProductOptions($syncItems, $productIdsToConfigurableIdsMap, $productsObject);
+            $productIdsToGroupIdsMap = $this->yotpoResource->getGroupProductIds($productsId);
+            $productIdsToParentIdsMap = $productIdsToConfigurableIdsMap + $productIdsToGroupIdsMap;
+            foreach ($productIdsToParentIdsMap as $simpleId => $parentId) {
                 $simpleProductObj = $productsObject[$simpleId];
                 if ($simpleProductObj->isVisibleInSiteVisibility()) {
                     $visibleVariantsData[$simpleProductObj->getId()] = $simpleProductObj;
@@ -232,8 +232,8 @@ class Data extends Main
             }
         }
         $return['sync_data'] = $syncItems;
-        $return['parents_ids'] = $parentIds;
-        $yotpoData = $this->fetchYotpoData($productsId, $parentIds);
+        $return['parents_ids'] = $productIdsToParentIdsMap;
+        $yotpoData = $this->fetchYotpoData($productsId, $productIdsToParentIdsMap);
         $return['yotpo_data'] = $yotpoData['yotpo_data'];
         $return['visible_variants'] = $visibleVariantsData;
         return $return;

--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -219,7 +219,8 @@ class Data extends Main
         $visibleVariantsData = [];
         $parentIds = [];
         if (!$isVariantsDataIncluded) {
-            $configIds = $this->yotpoResource->getConfigProductIds($productsId);
+            $configIdsToCheck = $this->yotpoResource->getConfigProductIds($productsId);
+            $configIds = $this->filterNotConfigurableProducts($configIdsToCheck);
             $syncItems = $this->mergeProductOptions($syncItems, $configIds, $productsObject);
             $groupIds = $this->yotpoResource->getGroupProductIds($productsId);
             $parentIds = $configIds + $groupIds;
@@ -277,12 +278,6 @@ class Data extends Main
      */
     protected function getChildOptions($parentProduct)
     {
-        $this->logger->info(
-            __(
-                'Executing getChildOptions for product ID %1',
-                $parentProduct->getId()
-            )
-        );
         if (!isset($this->parentOptions[$parentProduct->getId()])) {
             $options = $parentProduct->getTypeInstance()->getConfigurableAttributesAsArray($parentProduct);
             $this->parentOptions[$parentProduct->getId()] = $this->arrangeConfigOptions($options);
@@ -545,5 +540,41 @@ class Data extends Main
     {
         $externalId = $yotpoItemData['external_id'];
         return ['external_id' => $externalId];
+    }
+
+    /**
+     * @param array<string, integer> $productIds
+     * @return array<string, integer>
+     */
+    private function filterNotConfigurableProducts($productIds) {
+        if (!$productIds) {
+            return [];
+        }
+
+        $filteredProductIds = $productIds;
+        $configurableProductTypeCode = \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE;
+
+        $productCollection = $this->collectionFactory->create();
+        $productCollection->addAttributeToSelect('*');
+        $productCollection->addAttributeToFilter('entity_id', ['in' => $filteredProductIds]);
+        $products = $productCollection->getItems();
+
+        foreach ($products as $product) {
+            if ($product->getTypeId() != $configurableProductTypeCode) {
+                $keysToDeleteFromMap = array_keys($filteredProductIds, $product->getId());
+                foreach ($keysToDeleteFromMap as $keyToDeleteFromMap) {
+                    $this->logger->info(
+                        __(
+                            'A non-configurable product is being filtered - Key: %1, Product ID: %2',
+                            $keyToDeleteFromMap,
+                            $productIds[$keyToDeleteFromMap]
+                        )
+                    );
+                    unset($filteredProductIds[$keyToDeleteFromMap]);
+                }
+            }
+        }
+
+        return $filteredProductIds;
     }
 }

--- a/Model/Sync/Orders/Data.php
+++ b/Model/Sync/Orders/Data.php
@@ -144,12 +144,18 @@ class Data extends AbstractData
         $shippingAddress = $order->getShippingAddress();
         $orderStatus = $order->getStatus();
         $mappedYotpoOrderStatus = $this->getYotpoOrderStatus($orderStatus);
+        $payment = $order->getPayment();
+        $paymentMethod = null;
+        if ($payment !== null) {
+            $paymentMethod = $payment->getMethodInstance()->getTitle();
+        }
+
         $data = [
             'order' => [
                 'order_date' => $this->coreHelper->formatDate($order->getCreatedAt()),
                 'checkout_token' => $order->getQuoteId(),
                 /** @phpstan-ignore-next-line */
-                'payment_method' => $order->getPayment()->getMethodInstance()->getTitle(),
+                'payment_method' => $paymentMethod,
                 'total_price' => $order->getGrandTotal(),
                 'subtotal_price' => $order->getSubtotal() + $order->getDiscountAmount(),
                 'currency' => $order->getOrderCurrencyCode(),


### PR DESCRIPTION
## Introduction
Cron fails right after being executed.

![image (16)](https://user-images.githubusercontent.com/45664120/158491311-a97338da-5bb3-4401-8352-34901a438504.png)

## Issues
1. Order is returning null Payment object. \
In `Orders/Data#prepareData`, `getMethodInstance` is called on the null Payment object, which raises a null pointer exception. \
After looking at [this](https://magento.stackexchange.com/questions/300544/magento-2-3-3-uncaught-error-call-to-a-member-function-getpayment-on-null) thread, I understood that the specific order that is failing the process might be corrupt. \
When trying to get into the order's page in the Magento admin, the same type of exception was thrown.
In this case, order ID 990939 is corrupt.
![image (15)](https://user-images.githubusercontent.com/45664120/158491745-121d0b9c-23fa-4f7b-b419-ef902654f9fc.png)


2. Simple products are returned when looking for configurable parent products. \
Following that, the process is trying to call `getConfigurableAttributesAsArray` on simple products, which is a method that is available for configurable products only. This throws an exception. \
In this case, product ID 39101 was returned as configurable, even though it's a simple product. \
I investigated the implementation of `Magento\ConfigurableProduct\Model\Product\Type\Configurable#getParentIdsByChild`, which gets the parent IDs of a certain child directly by querying the DB.

## Fixes
1. Set payment method as empty string in case payment object is null.
2. After getting the products from `getParentIdsByChild`, I've added a check that filters all of the products that are not configurable from the array.
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/45664120/158496343-51556f5a-1e84-477c-aad5-01fc0823f3ee.png">
