### PR TITLE
COR-FIX detached variants raise exception in prepareOptions

### DIFF
--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -318,9 +318,14 @@ class Data extends Main
             if (isset($this->parentOptions[$id])
                 && $options = $this->parentOptions[$id]) {
                 foreach ($options as $attribute_code => $option) {
+                    $simpleProductAttributeCode = $productObjects[$key]->getData($attribute_code);
+                    if ($simpleProductAttributeCode === null) {
+                        continue;
+                    }
+
                     $configOptions[] = [
                         'name' => $option['label'],
-                        'value' => $option[$productObjects[$key]->getData($attribute_code)]
+                        'value' => $option[$simpleProductAttributeCode]
                     ];
                 }
                 $syncItems[$key]['options'] = $configOptions;


### PR DESCRIPTION
## Description
A configurable product and all of its variants are associated with a certain attributes set.
When changing the attribute set of one of the variants to an attribute set different from the one configured for the configurable product, the variant is being detached from the configurable product, and becomes a regular simple product.
Some of the Magento tables (such as `catalog_product_super_link`) still keep this relation.
This causes `getParentIdsByChild` to return the configurable product as the simple's parent product - even though it is not anymore.
When mapping the options for the parent product, in the `Catalog/Data#prepareOptions` method, we're trying to get an attribute value for an attribute that doesn't necessarily exist in the newly configured attribute set of the simple product.
This is causing the process to raise an exception.
This bug was discovered using Magento's performance testing dataset.

## Solution
When mapping the option values, check if the attribute code exists for the product.
If not, skip the mapping.
