### PR TITLE
fix(Catalog/Processor/Main#isProductParentYotpoIdFound):added checking yotpo_id value not falsly

### DIFF
--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -298,6 +298,19 @@ class Processor extends Main
                                 $parentProductYotpoId
                             )
                         );
+                    } else {
+                        $this->yotpoCatalogLogger->info(
+                            __(
+                                'Failed creating parent product for a variant, skipping variant sync -
+                                Store ID: %1, Store Name: %2, Parent Entity ID: %3, Yotpo ID: %4',
+                                $storeId,
+                                $this->coreConfig->getStoreName($storeId),
+                                $parentItemId,
+                                $parentProductYotpoId
+                            )
+                        );
+
+                        continue;
                     }
                 }
             }

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -689,7 +689,7 @@ class Main extends AbstractJobs
      */
     public function isProductParentYotpoIdFound($yotpoData, $parentId): bool
     {
-        return isset($yotpoData[$parentId]) && isset($yotpoData[$parentId]['yotpo_id']);
+        return isset($yotpoData[$parentId]) && isset($yotpoData[$parentId]['yotpo_id']) && $yotpoData[$parentId]['yotpo_id'];
     }
 
     /**


### PR DESCRIPTION
## Description

1. The parent product of a variant may have yotpo_id with value 0 if it failed to sync in previous iterations. \
Added a check to sync parent product if yotpo_id is falsly.
2. If the parent product failed syncing as parent of the variant sync itself, we would continue with parent ID 0. \
Added a continue if the parent product fails.