### PR TITLE
COR-FIX fix for Request#send with returning response of token api error retry

### DIFF
--- a/Model/Api/Request.php
+++ b/Model/Api/Request.php
@@ -93,7 +93,7 @@ class Request
         if (!$successFullResponse && $this->yotpoResponse->invalidToken($response) && $this->retryRequestInvalidToken) {
             $this->getAuthToken(true); //generate new token
             $this->retryRequestInvalidToken--;
-            $this->send($method, $endPoint, $data);
+            return $this->send($method, $endPoint, $data);
         }
         return $response;
     }


### PR DESCRIPTION
## Description

When getting 401 or 403 errors from the API, the extension generates a new API token and retries the request.
However, this will return the original API response (401/3), which will be written in the sync tables in return.
I've added a return to the call of send so the response of the retried send would be returned instead of the original one.