### PR TITLE
COR-2004 Changing real time products sync flows to also sync product that were changed

### DIFF
--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -392,9 +392,9 @@ class Processor extends Main
                     unset($this->retryItems[$storeId][$itemEntityId]);
                 }
 
-                if (count($returnResponse['four_not_four_data'])) {
-                    foreach ($returnResponse['four_not_four_data'] as $retryId) {
-                        if ($this->isImmediateRetry($response, $this->entity, $isVisibleVariantsSync . $retryId, $storeId)) {
+                if (count($returnResponse['failed_product_ids_for_retry'])) {
+                    foreach ($returnResponse['failed_product_ids_for_retry'] as $retryId) {
+                        if ($this->isImmediateRetry($response, $this->entity, $isVisibleVariantsSync.$retryId, $storeId)) {
                             $this->retryItems[$storeId][$retryId] = $retryId;
                             $this->setImmediateRetryAlreadyDone(
                                 $this->entity,

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -738,9 +738,8 @@ class Processor extends Main
 
     /**
      * Check and sync the products if not already synced
-     *
-     * @param array <mixed> $productIds
-     * @param array <mixed> $visibleItems
+     * @param array<mixed> $productIds
+     * @param array<mixed> $visibleItems
      * @param int|null $storeId
      * @return bool
      */
@@ -759,9 +758,8 @@ class Processor extends Main
 
     /**
      * Get the productIds od the products that are not synced
-     *
-     * @param array <mixed> $productIds
-     * @param array <mixed> $visibleItems
+     * @param array<mixed> $productIds
+     * @param array<mixed> $visibleItems
      * @param int|null $storeId
      * @return mixed
      */
@@ -773,9 +771,18 @@ class Processor extends Main
             if (!$product) {
                 continue;
             }
+
             $itemsMap[$product->getId()] = $product;
         }
-        return $this->syncDataMain->getProductIds($productIds, $storeId, $itemsMap);
+        $productsIdsToUpdate = [];
+        $productsIdsToCreate = $this->syncDataMain->getProductIds($productIds, $storeId, $itemsMap);
+
+        if (!$this->coreConfig->isCatalogSyncActive($storeId)) {
+            $productsIdsToCheck = array_diff($productIds, $productsIdsToCreate);
+            $productsIdsToUpdate = $this->productsSyncService->findProductsThatShouldBeSyncedByAttribute($productsIdsToCheck);
+        }
+
+        return array_merge($productsIdsToUpdate, $productsIdsToCreate);
     }
 
     /**

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -211,7 +211,7 @@ class Main extends AbstractJobs
         $visibleVariants = false
     ) {
         $storeId = $this->coreConfig->getStoreId();
-        $fourNotFourData = [];
+        $failedProductSyncIdsForRetry = [];
         switch ($apiParam['method']) {
             case $this->coreConfig->getProductSyncMethod('createProduct'):
             case $this->coreConfig->getProductSyncMethod('createProductVariant'):
@@ -244,15 +244,15 @@ class Main extends AbstractJobs
                     }
                 } else {
                     if ($this->isImmediateRetryResponse($response->getData('status'))) {
-                        $fnfParentIdFromYotpoTbl = '';
+                        $BadRequestProductSyncParentId = '';
                         if ($apiParam['method'] === $this->coreConfig->getProductSyncMethod('updateProductVariant')) {
-                            $fnfParentIdFromYotpoTbl = $this->getFourNotFourParentId($apiParam);
+                            $BadRequestProductSyncParentId = $this->getProductParentIdFromSyncTable($apiParam);
                         }
-                        if ($fnfParentIdFromYotpoTbl) {
-                            $fourNotFourData[] = $fnfParentIdFromYotpoTbl;
+                        if ($BadRequestProductSyncParentId) {
+                            $failedProductSyncIdsForRetry[] = $BadRequestProductSyncParentId;
                         }
                         if (array_key_exists('external_id', $data)) {
-                            $fourNotFourData[] = $data['external_id'];
+                            $failedProductSyncIdsForRetry[] = $data['external_id'];
                         }
                     }
                     $this->writeFailedLog($apiParam['method'], $storeId);
@@ -275,7 +275,7 @@ class Main extends AbstractJobs
         return [
             'temp_sql' => $tempSqlArray,
             'external_id' => array_filter($externalIds),
-            'four_not_four_data' => $fourNotFourData
+            'failed_product_ids_for_retry' => $failedProductSyncIdsForRetry
         ];
     }
 
@@ -530,20 +530,21 @@ class Main extends AbstractJobs
      * @return int|string
      * @throws NoSuchEntityException
      */
-    protected function getFourNotFourParentId($apiParam)
+    protected function getProductParentIdFromSyncTable($apiParam)
     {
-        $return = 0;
+        $yotpoId = isset($apiParam['yotpo_id_parent']) ? $apiParam['yotpo_id_parent'] : 0;
+        if (!$yotpoId) {
+            return 0;
+        }
+
         $connection = $this->getConnection();
         $tableName = $this->getTableName('yotpo_product_sync');
-        $yotpoId = isset($apiParam['yotpo_id_parent']) ? $apiParam['yotpo_id_parent'] : 0;
-        if ($yotpoId) {
-            $select = $connection->select()
-                ->from($tableName, 'product_id')
-                ->where('yotpo_id = ?', $yotpoId)
-                ->where('store_id = ?', $this->coreConfig->getStoreId());
-            $return = $connection->fetchOne($select);
-        }
-        return $return;
+        $productIdByYotpoIdAndStoreIdQuery = $connection->select()
+            ->from($tableName, 'product_id')
+            ->where('yotpo_id = ?', $yotpoId)
+            ->where('store_id = ?', $this->coreConfig->getStoreId());
+
+        return $connection->fetchOne($productIdByYotpoIdAndStoreIdQuery);
     }
 
     /**
@@ -559,7 +560,7 @@ class Main extends AbstractJobs
         $parentYotpoId = '';
         $childYotpoId = '';
 
-        $parentId = $this->getFourNotFourParentId($apiParam);
+        $parentId = $this->getProductParentIdFromSyncTable($apiParam);
         if ($params['method'] === $this->coreConfig->getProductSyncMethod('deleteProduct') || $parentId) {
             $requestId = $parentId ?: $itemId;
             $url = $this->coreConfig->getEndpoint('products');

--- a/Model/Sync/Catalog/Services/ProductsSyncService.php
+++ b/Model/Sync/Catalog/Services/ProductsSyncService.php
@@ -5,6 +5,7 @@ namespace Yotpo\Core\Model\Sync\Catalog\Services;
 use Yotpo\Core\Model\AbstractJobs;
 use Magento\Framework\App\ResourceConnection;
 use Magento\Store\Model\App\Emulation as AppEmulation;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Yotpo\Core\Model\Config as CoreConfig;
 
 class ProductsSyncService extends AbstractJobs
@@ -17,19 +18,27 @@ class ProductsSyncService extends AbstractJobs
     protected $coreConfig;
 
     /**
+     * @var CollectionFactory
+     */
+    protected $collectionFactory;
+
+    /**
      * Processor constructor.
      * @param AppEmulation $appEmulation
      * @param ResourceConnection $resourceConnection
      * @param CoreConfig $coreConfig
+     * @param CollectionFactory $collectionFactory
      * @throws \Magento\Framework\Exception\LocalizedException
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function __construct(
         AppEmulation $appEmulation,
         ResourceConnection $resourceConnection,
-        CoreConfig $coreConfig
+        CoreConfig $coreConfig,
+        CollectionFactory $collectionFactory
     ) {
         $this->coreConfig = $coreConfig;
+        $this->collectionFactory = $collectionFactory;
         parent::__construct($appEmulation, $resourceConnection);
     }
 
@@ -66,6 +75,31 @@ class ProductsSyncService extends AbstractJobs
         );
         $items = $connection->fetchAssoc($select, 'product_id');
         return array_keys($items);
+    }
+
+    /**
+     * @param array<integer> $productIds
+     * @return array
+     */
+    public function findProductsThatShouldBeSyncedByAttribute($productIds)
+    {
+        $collection = $this->collectionFactory->create();
+        $collection->addAttributeToSelect('*');
+        $collection->addAttributeToFilter(
+            [
+                ['attribute' => CoreConfig::CATALOG_SYNC_ATTR_CODE, 'null' => true],
+                ['attribute' => CoreConfig::CATALOG_SYNC_ATTR_CODE, 'eq' => '0'],
+            ]
+        );
+        $collection->addFieldToFilter('entity_id', ['in' => $productIds]);
+
+        $productIdsForSync = [];
+        $productsCollection = $collection->getItems();
+        foreach ($productsCollection as $product) {
+            $productIdsForSync[] = $product->getId();
+        }
+
+        return $productIdsForSync;
     }
 
     /**


### PR DESCRIPTION
## Description
In case the catalog sync is disabled, the product data in Yotpo will never be updated.
We've added logic to update the product data through the orders sync in case the catalog sync is disabled. 