### PR TITLE
COR-FIX UpdateCategoryAttribute deleted trailing comma

### DIFF
--- a/Setup/Patch/Data/UpdateCategoryAttribute.php
+++ b/Setup/Patch/Data/UpdateCategoryAttribute.php
@@ -42,7 +42,7 @@ class UpdateCategoryAttribute implements DataPatchInterface
             'catalog_category',
             'synced_to_yotpo_collection',
             'is_global',
-            ScopedAttributeInterface::SCOPE_STORE,
+            ScopedAttributeInterface::SCOPE_STORE
         );
         $eavSetup->updateAttribute(
             'catalog_category',


### PR DESCRIPTION
## Description
Trailing commas are supported in PHP 7.3 and above.
This causes exceptions to be thrown for customers during the installation process for customers with PHP 7.2.