### PR TITLE
COR-FIX Added handling for null vm_category_products value in category observer SaveBefore

### DIFF
--- a/Observer/Category/SaveBefore.php
+++ b/Observer/Category/SaveBefore.php
@@ -86,13 +86,17 @@ class SaveBefore implements ObserverInterface
             $this->catalogCategoryProductService->getProductIdsFromCategoryProductsTableByCategoryId(
                 $categoryId
             );
+
         $productIdToPositionInCategoryMapBeforeSave =
             json_decode(
                 $this->request->getParam('vm_category_products'),
                 true
             );
-        $productIdsInCategoryBeforeSave = array_keys($productIdToPositionInCategoryMapBeforeSave);
+        if ($productIdToPositionInCategoryMapBeforeSave === null) {
+            return;
+        }
 
+        $productIdsInCategoryBeforeSave = array_keys($productIdToPositionInCategoryMapBeforeSave);
         $productsAddedToCategory = array_diff($productIdsInCategoryBeforeSave, $currentProductIdsInCategory);
         $productsDeletedFromCategory = array_diff($currentProductIdsInCategory, $productIdsInCategoryBeforeSave);
         $storeIdsSuccessfullySyncedWithCategory =

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-core",
     "description": "Yotpo Reviews core extension for Magento2",
-    "version": "4.0.22",
+    "version": "4.0.23",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_Core" setup_version="4.0.22" />
+    <module name="Yotpo_Core" setup_version="4.0.23" />
 </config>


### PR DESCRIPTION
## Introduction
The bug was reported by a customer.

> **Description**
> We're seeing two separate issues, but both related to the megamenu. The first issue we're seeing is that we can't update the "Include in Menu" flag. We're also seeing a second issue where we aren't able to update content blocks for the category. In both cases we get an error message when saving. It'll show the update we made at first, but if we leave the category and then go back, we'll see the change actually didn't stick.
>  
> **Issue Impact**
> We have new content that needs to go live, but we currently can't get it up
>  
> **Steps to Replicate**
> Include in Menu Flag: Catalog > Categories > Click into any category and attempt to enable the "Include in Menu" flag
>  
> Content Block Update: Catalog > Categories > Click into any category > Open "Content" tab > Try to update the "Add CMS Block" dropdown

## Developer Notes
Some of the `validate` requests from the category saving action are not being sent with `vm_category_products` value in the Request payload.

The solution is to return the observer when the value is NULL.