### PR TITLE
COR cleaning sync tables and attribute values on app key change

### DIFF
--- a/Console/Command/ResetYotpoSync.php
+++ b/Console/Command/ResetYotpoSync.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Yotpo\Core\Console\Command;
+
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Magento\Framework\App\State as AppState;
+use Yotpo\Core\Model\Config;
+use Yotpo\Core\Model\Sync\ResetEntitiesSync;
+
+/**
+ * Class ReSetYotpoSync - Manage Yotpo Reset Sync
+ */
+class ResetYotpoSync extends Command
+{
+    const YOTPO_ENTITY              = 'entity';
+    const STORE_ID                  = 'store_id';
+    const YOTPO_ENTITY_ALL          = 'all';
+    const YOTPO_ENTITY_CUSTOMERS    = 'customer';
+    const YOTPO_ENTITY_ORDERS       = 'order';
+    const YOTPO_ENTITY_CATALOG      = 'catalog';
+
+    /**
+     * @var string[]
+     */
+    protected $yotpoEntities = ['order', 'customer', 'catalog', 'all'];
+
+    /**
+     * @var AppState
+     */
+    protected $appState;
+
+    /**
+     * @var ResetEntitiesSync
+     */
+    protected $syncReset;
+
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    /**
+     * ResetYotpoSync constructor.
+     * @param AppState $appState
+     * @param ResetEntitiesSync $syncReset
+     * @param string|null $name
+     */
+    public function __construct(
+        ResetEntitiesSync $syncReset,
+        AppState $appState,
+        Config $config,
+        string $name = null
+    ) {
+        $this->syncReset = $syncReset;
+        $this->appState = $appState;
+        $this->config = $config;
+        parent::__construct($name);
+    }
+
+    /**
+     * Configures the current command.
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $options = [
+            new InputOption(
+                self::YOTPO_ENTITY,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Entity'
+            ),
+            new InputOption(
+                self::STORE_ID,
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Store ID'
+            ),
+        ];
+
+        $this->setName('yotpo:resetsync')
+            ->setDescription('Reset Sync')
+            ->setDefinition($options);
+
+        parent::configure();
+    }
+
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return $this|int
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->setAreaCodeIfNotConfigured();
+        $storeId = $input->getOption(self::STORE_ID);
+        if ($storeId) {
+            $storeIds = [$storeId];
+        } else {
+            $storeIds = $this->config->getAllStoreIds();
+        }
+        if (!$storeIds) {
+            return $this;
+        }
+        foreach ($storeIds as $storeId) {
+            $yotpoEntityInput = $input->getOption(self::YOTPO_ENTITY);
+            if (!$yotpoEntityInput) {
+                return $this;
+            }
+            if (!is_array($yotpoEntityInput)) {
+                $yotpoEntityInput = [$yotpoEntityInput];
+            }
+            $this->resetYotpoSyncByEntity($yotpoEntityInput, $storeId, $output);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return void
+     * @throws LocalizedException
+     */
+    public function setAreaCodeIfNotConfigured()
+    {
+        try {
+            $this->appState->getAreaCode();
+        } catch (LocalizedException $e) {
+            $this->appState->setAreaCode(\Magento\Framework\App\Area::AREA_CRONTAB);
+        }
+    }
+
+    /**
+     * @param int $storeId
+     * @return void
+     */
+    public function resetAllSync($storeId)
+    {
+        $this->syncReset->resetSync($storeId);
+    }
+
+    /**
+     * @param int $storeId
+     * @return void
+     */
+    public function resetCatalogSync($storeId)
+    {
+        $this->syncReset->resetCatalogSync($storeId);
+    }
+
+    /**
+     * @param int $storeId
+     * @return void
+     */
+    public function resetCustomersSync($storeId)
+    {
+        $this->syncReset->resetCustomersSync($storeId);
+    }
+
+    /**
+     * @param int $storeId
+     * @return void
+     */
+    public function resetOrdersSync($storeId)
+    {
+        $this->syncReset->resetOrdersSync($storeId);
+    }
+
+    /**
+     * @param array <bool|string|null> $yotpoEntityInput
+     * @param int $storeId
+     * @param OutputInterface $output
+     * @return void
+     * @throws NoSuchEntityException
+     */
+    protected function resetYotpoSyncByEntity($yotpoEntityInput, $storeId, OutputInterface $output)
+    {
+        foreach ($yotpoEntityInput as $yotpoEntity) {
+            switch ($yotpoEntity) {
+                case self::YOTPO_ENTITY_CATALOG:
+                    $this->resetCatalogSync($storeId);
+                    break;
+                case self::YOTPO_ENTITY_CUSTOMERS:
+                    $this->resetCustomersSync($storeId);
+                    break;
+                case self::YOTPO_ENTITY_ORDERS:
+                    $this->resetOrdersSync($storeId);
+                    break;
+                case self::YOTPO_ENTITY_ALL:
+                    $this->resetAllSync($storeId);
+                    break;
+                default:
+                    $output->writeln('Yotpo Reset Sync');
+                    break;
+            }
+            if (in_array($yotpoEntity, $this->yotpoEntities)) {
+                $storeName = $this->config->getStoreName($storeId);
+                $output->writeln(
+                    'Sync reset completed for Entity - ' . $yotpoEntity . ', Store ID - ' . $storeName
+                );
+            } else {
+                $output->writeln('Entity - ' . $yotpoEntity . ' does not exist');
+            }
+        }
+    }
+}

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -141,6 +141,18 @@ class Config
             [
                 'path' => 'yotpo_core/widget_settings/marketing_settings/attr_customer'
             ],
+        'reset_sync_in_progress_catalog' =>
+            [
+                'path' => 'yotpo_core/sync_settings/reset_sync/reset_sync_in_progress_catalog'
+            ],
+        'reset_sync_in_progress_order' =>
+            [
+                'path' => 'yotpo_core/sync_settings/reset_sync/reset_sync_in_progress_order'
+            ],
+        'reset_sync_in_progress_customer' =>
+            [
+                'path' => 'yotpo_core/sync_settings/reset_sync/reset_sync_in_progress_customer'
+            ]
     ];
 
     /**
@@ -699,5 +711,17 @@ class Config
     public function getSuccessfulResponseCodes()
     {
         return $this->successfulResponseCodes;
+    }
+
+    /**
+     * @param int|null $scopeId
+     * @param string $entity
+     * @return boolean
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function isSyncResetInProgress($scopeId, $entity)
+    {
+        return (bool)$this->getConfig('reset_sync_in_progress_' . $entity, $scopeId);
     }
 }

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -143,6 +143,17 @@ class Processor extends Main
                 $this->emulateFrontendArea($storeId);
                 try {
                     $disabled = false;
+                    if ($this->coreConfig->isSyncResetInProgress($storeId, 'catalog')) {
+                        $disabled = true;
+                        $this->yotpoCatalogLogger->info(
+                            __(
+                                'Product sync is skipped because catalog sync reset is in progress
+                         - Magento Store ID: %1, Name: %2',
+                                $storeId,
+                                $this->coreConfig->getStoreName($storeId)
+                            )
+                        );
+                    }
                     if (!$this->coreConfig->isEnabled()) {
                         $disabled = true;
                         $this->yotpoCatalogLogger->info(

--- a/Model/Sync/Category/Processor/ProcessByCategory.php
+++ b/Model/Sync/Category/Processor/ProcessByCategory.php
@@ -105,7 +105,26 @@ class ProcessByCategory extends Main
                         $this->config->getStoreName($storeId) . PHP_EOL;
                 }
                 $this->emulateFrontendArea($storeId);
+                if ($this->config->isSyncResetInProgress($storeId, 'catalog')) {
+                    $this->yotpoCoreCatalogLogger->info(
+                        __(
+                            'Category sync is skipped because catalog sync
+                             reset is in progress - Magento Store ID: %1, Name: %2',
+                            $storeId,
+                            $this->config->getStoreName($storeId)
+                        )
+                    );
+                    $this->stopEnvironmentEmulation();
+                    continue;
+                }
                 if (!$this->config->isCatalogSyncActive()) {
+                    $this->yotpoCoreCatalogLogger->info(
+                        __(
+                            'Catalog Sync is Disabled - Magento Store ID: %1, Name: %2',
+                            $storeId,
+                            $this->config->getStoreName($storeId)
+                        )
+                    );
                     $this->stopEnvironmentEmulation();
                     continue;
                 }
@@ -172,6 +191,17 @@ class ProcessByCategory extends Main
         $collection->getSelect()->limit($batchSize);
         $magentoCategories = [];
         foreach ($collection->getItems() as $category) {
+            if ($this->config->isSyncResetInProgress($storeId, 'catalog')) {
+                $this->yotpoCoreCatalogLogger->info(
+                    __(
+                        'Category sync is skipped because catalog sync
+                             reset is in progress - Magento Store ID: %1, Name: %2',
+                        $storeId,
+                        $this->config->getStoreName($storeId)
+                    )
+                );
+                continue;
+            }
             $magentoCategories[$category->getId()] = $category;
         }
         $existingCollections = $this->getExistingCollectionIds(array_keys($magentoCategories));

--- a/Model/Sync/Orders/Processor.php
+++ b/Model/Sync/Orders/Processor.php
@@ -164,6 +164,9 @@ class Processor extends Main
     {
         $storeId = $order->getStoreId();
         $this->emulateFrontendArea((int)$storeId);
+        if ($this->config->isSyncResetInProgress($storeId, 'order')) {
+            return;
+        }
         $this->currentStoreId = $this->config->getStoreId();
         $this->yotpoOrdersLogger->info(
             __(
@@ -202,6 +205,18 @@ class Processor extends Main
 
         $ordersWithMissedProducts = [];
         foreach ($orderItems as $order) {
+            $storeId = $order->getStoreId();
+            if ($this->config->isSyncResetInProgress($storeId, 'order')) {
+                $this->yotpoOrdersLogger->info(
+                    __(
+                        'Order sync is skipped because order sync reset is in progress
+                         - Magento Store ID: %1, Name: %2',
+                        $storeId,
+                        $this->config->getStoreName($storeId)
+                    )
+                );
+                continue;
+            }
             $productsMissing = $this->checkMissingProducts($order);
             if ($productsMissing) {
                 $this->yotpoOrdersLogger->info('Products not exist for order  : ' . $order->getId(), []);

--- a/Model/Sync/Reset/Catalog.php
+++ b/Model/Sync/Reset/Catalog.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Yotpo\Core\Model\Sync\Reset;
+
+use Yotpo\Core\Model\Config as CoreConfig;
+
+class Catalog extends Main
+{
+    const PRODUCT_SYNC_TABLE = 'yotpo_product_sync';
+    const CATEGORY_SYNC_TABLE = 'yotpo_category_sync';
+    const CATEGORY_PRODUCT_MAP_SYNC_TABLE = 'yotpo_collections_products_sync';
+    const CRONJOB_CODES = ['yotpo_cron_core_category_sync','yotpo_cron_core_products_sync'];
+    const YOTPO_ENTITY_NAME = 'catalog';
+
+    /**
+     * @return string
+     */
+    public function getYotpoEntityName()
+    {
+        return self::YOTPO_ENTITY_NAME;
+    }
+
+    /**
+     * @param int $storeId
+     * @param boolean $clearSyncTables
+     * @return void
+     * @throws \Zend_Db_Statement_Exception
+     */
+    public function resetSync($storeId, $clearSyncTables = true)
+    {
+        parent::resetSync($storeId);
+        $this->resetCatalogSyncAttributes($storeId);
+        $this->setResetInProgressConfig($storeId, '0');
+    }
+
+    /**
+     * @return array <string>
+     */
+    protected function getTableResourceNames()
+    {
+        return [self::PRODUCT_SYNC_TABLE, self::CATEGORY_SYNC_TABLE, self::CATEGORY_PRODUCT_MAP_SYNC_TABLE];
+    }
+
+    /**
+     * @return array <string>
+     */
+    protected function getCronJobCodes()
+    {
+        return self::CRONJOB_CODES;
+    }
+
+    /**
+     * @param int $storeId
+     * @return void
+     */
+    private function resetCatalogSyncAttributes($storeId)
+    {
+        $dataSet = [
+            [
+                'table_name' => 'catalog_category_entity_int',
+                'attribute_code' => CoreConfig::CATEGORY_SYNC_ATTR_CODE
+            ],
+            [
+                'table_name' => 'catalog_product_entity_int',
+                'attribute_code' => CoreConfig::CATALOG_SYNC_ATTR_CODE
+            ],
+        ];
+        foreach ($dataSet as $data) {
+            $this->updateEntityAttributeTableData($storeId, $data['attribute_code'], $data['table_name']);
+        }
+    }
+}

--- a/Model/Sync/Reset/Customers.php
+++ b/Model/Sync/Reset/Customers.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Yotpo\Core\Model\Sync\Reset;
+
+class Customers extends Main
+{
+}

--- a/Model/Sync/Reset/Main.php
+++ b/Model/Sync/Reset/Main.php
@@ -1,0 +1,272 @@
+<?php
+
+namespace Yotpo\Core\Model\Sync\Reset;
+
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\ResourceConnection;
+use Yotpo\Core\Model\Config;
+use Yotpo\Core\Model\Sync\Data\Main as SyncDataMain;
+
+class Main
+{
+    const DELETE_LIMIT = 10000;
+    const UPDATE_LIMIT = 2000;
+
+    /**
+     * @var ResourceConnection
+     */
+    protected $resourceConnection;
+
+    /**
+     * @var Config
+     */
+    protected $config;
+
+    /**
+     * @var TypeListInterface
+     */
+    protected $cacheTypeList;
+
+    /**
+     * @var SyncDataMain
+     */
+    protected $syncDataMain;
+
+    /**
+     * @param ResourceConnection $resourceConnection
+     * @param Config $config
+     * @param TypeListInterface $cacheTypeList
+     * @param SyncDataMain $syncDataMain
+     */
+    public function __construct(
+        ResourceConnection $resourceConnection,
+        Config $config,
+        TypeListInterface $cacheTypeList,
+        SyncDataMain $syncDataMain
+    ) {
+        $this->resourceConnection = $resourceConnection;
+        $this->config = $config;
+        $this->cacheTypeList = $cacheTypeList;
+        $this->syncDataMain = $syncDataMain;
+    }
+
+    /**
+     * @param int $storeId
+     * @param boolean $clearSyncTables
+     * @return void
+     * @throws \Zend_Db_Statement_Exception
+     */
+    public function resetSync($storeId, $clearSyncTables = true)
+    {
+        $this->setResetInProgressConfig($storeId, '1');
+        $this->deleteRunningCronSchedules();
+        if ($clearSyncTables) {
+            $this->deleteAllRecordsFromTables($storeId);
+        }
+    }
+
+    /**
+     * @return array <string>
+     */
+    protected function getTableResourceNames()
+    {
+        return [];
+    }
+
+    /**
+     * @return array <string>
+     */
+    protected function getCronJobCodes()
+    {
+        return [];
+    }
+
+    /**
+     * @return string
+     */
+    protected function getYotpoEntityName()
+    {
+        return '';
+    }
+
+    /**
+     * @param int $storeId
+     * @return void
+     * @throws \Zend_Db_Statement_Exception
+     */
+    private function deleteAllRecordsFromTables($storeId)
+    {
+        $tableResourceNames = $this->getTableResourceNames();
+        foreach ($tableResourceNames as $tableResourceName) {
+            $this->deleteAllRecordsFromTable($storeId, $tableResourceName);
+        }
+    }
+
+    /**
+     * @param int $storeId
+     * @param string $tableResourceName
+     * @return void
+     * @throws \Zend_Db_Statement_Exception
+     */
+    private function deleteAllRecordsFromTable($storeId, $tableResourceName)
+    {
+        $tableName = $this->resourceConnection->getTableName($tableResourceName);
+        $totalCount = $this->getTotalCount($tableName, $storeId);
+        if (!$totalCount) {
+            return;
+        }
+        $storeIdColumnName = $this->getStoreIdColumnName($tableName);
+        $connection  = $this->resourceConnection->getConnection();
+        while ($totalCount > 0) {
+            $totalCount -= self::DELETE_LIMIT;
+            $select = $connection
+                ->select()
+                ->from($tableName)
+                ->where($storeIdColumnName . ' = \''.$storeId.'\'')
+                ->limit(self::DELETE_LIMIT);
+
+            $query = $connection->deleteFromSelect($select, new \Zend_Db_Expr(''));
+            $connection->query($query);
+        }
+    }
+
+    /**
+     * @param string $tableName
+     * @param int $storeId
+     * @return int
+     * @throws \Zend_Db_Statement_Exception
+     */
+    private function getTotalCount($tableName, $storeId)
+    {
+        $storeIdColumnName = $this->getStoreIdColumnName($tableName);
+        $connection  = $this->resourceConnection->getConnection();
+        $query = $connection->select()
+            ->from($tableName)
+            ->where($storeIdColumnName . ' = ?', $storeId);
+        return $connection->query($query)->rowCount();
+    }
+
+    /**
+     * @param string $tableName
+     * @return string
+     */
+    private function getStoreIdColumnName($tableName)
+    {
+        if (stripos($tableName, Catalog::CATEGORY_PRODUCT_MAP_SYNC_TABLE) !== false) {
+            return 'magento_store_id';
+        }
+        return 'store_id';
+    }
+
+    /**
+     * @return void
+     */
+    private function deleteRunningCronSchedules()
+    {
+        $jobCodes = $this->getCronJobCodes();
+        if (!$jobCodes) {
+            return;
+        }
+        $connection  = $this->resourceConnection->getConnection();
+        $tableName = $this->resourceConnection->getTableName('cron_schedule');
+        $select = $connection
+            ->select()
+            ->from($tableName)
+            ->where('job_code IN (?)', $jobCodes)
+            ->where('status=\'running\'');
+        $query = $connection->deleteFromSelect($select, new \Zend_Db_Expr(''));
+        $connection->query($query);
+    }
+
+    /**
+     * @param int $storeId
+     * @param string $flag
+     * @return void
+     */
+    public function setResetInProgressConfig($storeId, $flag)
+    {
+        $yotpoEntityName = $this->getYotpoEntityName();
+        if (!$yotpoEntityName) {
+            return;
+        }
+        $key = 'reset_sync_in_progress_' . $yotpoEntityName;
+        $this->config->saveConfig($key, $flag, $storeId);
+        $this->cacheTypeList->cleanType(\Magento\Framework\App\Cache\Type\Config::TYPE_IDENTIFIER);
+    }
+
+    /**
+     * @param string $tableName
+     * @param int $attributeId
+     * @param int|null $storeId
+     * @return int
+     */
+    public function getCountOfEntities($tableName, $attributeId, $storeId = null)
+    {
+        $connection  = $this->resourceConnection->getConnection();
+        $tableName = $this->resourceConnection->getTableName($tableName);
+        $select = $connection->select();
+        $query = $select->reset()
+            ->from(
+                ['p' => $tableName]
+            );
+        if ($storeId) {
+            $query->where('store_id = ?', $storeId);
+        }
+        $query->where('attribute_id = ?', $attributeId);
+        $query->where('value = ?', 1);
+        return $connection->query($query)->rowCount();
+    }
+
+    /**
+     * @param int $storeId
+     * @param string $attributeCode
+     * @param string $tableName
+     * @return void
+     */
+    public function updateEntityAttributeTableData($storeId, $attributeCode, $tableName)
+    {
+        $connection =   $this->resourceConnection->getConnection();
+        $attributeId = $this->syncDataMain->getAttributeId($attributeCode);
+        $totalCount = $this->getCountOfEntities($tableName, $attributeId, $storeId);
+        $tableName = $this->resourceConnection->getTableName($tableName);
+        $limit = self::UPDATE_LIMIT;
+        while ($totalCount > 0) {
+            $updateQuery = sprintf(
+                'UPDATE `%s` SET `value` = %d WHERE `attribute_id` = %d AND `store_id` = %d AND
+                                    `value` = 1 LIMIT %d',
+                $tableName,
+                0,
+                $attributeId,
+                $storeId,
+                $limit
+            );
+            $connection->query($updateQuery);
+            $totalCount -= self::UPDATE_LIMIT;
+        }
+    }
+
+    /**
+     * @param string $attributeCode
+     * @param string $tableName
+     * @return void
+     */
+    public function updateEntityAttributeTableDataWithoutStoreId($attributeCode, $tableName)
+    {
+        $connection =   $this->resourceConnection->getConnection();
+        $attributeId = $this->syncDataMain->getAttributeId($attributeCode);
+        $totalCount = $this->getCountOfEntities($tableName, $attributeId);
+        $tableName = $this->resourceConnection->getTableName($tableName);
+        $limit = self::UPDATE_LIMIT;
+        while ($totalCount > 0) {
+            $updateQuery = sprintf(
+                'UPDATE `%s` SET `value` = %d WHERE `attribute_id` = %d AND `value` = 1 LIMIT %d',
+                $tableName,
+                0,
+                $attributeId,
+                $limit
+            );
+            $connection->query($updateQuery);
+            $totalCount -= self::UPDATE_LIMIT;
+        }
+    }
+}

--- a/Model/Sync/Reset/Orders.php
+++ b/Model/Sync/Reset/Orders.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Yotpo\Core\Model\Sync\Reset;
+
+class Orders extends Main
+{
+    const ORDERS_SYNC_TABLE = 'yotpo_orders_sync';
+    const CRONJOB_CODES = ['yotpo_cron_core_orders_sync'];
+
+    const ORDERS_TABLE = 'sales_order';
+    const ORDERS_DATA_LIMIT = 300;
+    const YOTPO_ENTITY_NAME = 'order';
+    const SYNCED_TO_YOTPO_ORDER_COLUMN = 'synced_to_yotpo_order';
+
+    /**
+     * @return array <string>
+     */
+    protected function getTableResourceNames()
+    {
+        return [self::ORDERS_SYNC_TABLE];
+    }
+
+    /**
+     * @return array <string>
+     */
+    protected function getCronJobCodes()
+    {
+        return self::CRONJOB_CODES;
+    }
+
+    /**
+     * @return string
+     */
+    public function getYotpoEntityName()
+    {
+        return self::YOTPO_ENTITY_NAME;
+    }
+
+    /**
+     * @param int $storeId
+     * @param boolean $clearSyncTables
+     * @return void
+     * @throws \Zend_Db_Statement_Exception
+     */
+    public function resetSync($storeId, $clearSyncTables = true)
+    {
+        parent::resetSync($storeId, false);
+        $this->clearSyncTracks($storeId);
+        $this->setResetInProgressConfig($storeId, '0');
+    }
+
+    /**
+     * @param int $storeId
+     * @return void
+     */
+    private function clearSyncTracks($storeId)
+    {
+        $connection  = $this->resourceConnection->getConnection();
+        $table = $this->resourceConnection->getTableName(self::ORDERS_TABLE);
+        $select = $connection->select()
+            ->from($table, 'entity_id')
+            ->where('store_id', $storeId);
+
+        $offset = 0;
+        do {
+            $entityIds = $connection->fetchCol($select->limit(self::ORDERS_DATA_LIMIT, $offset));
+            $this->resetOrderSyncFlag($storeId, $entityIds);
+            $this->cleanUpSyncTable($entityIds);
+            $offset += self::ORDERS_DATA_LIMIT;
+        } while ($entityIds);
+    }
+
+    /**
+     * @param int $storeId
+     * @param array <int> $orderIds
+     * @return void
+     */
+    public function resetOrderSyncFlag($storeId, $orderIds)
+    {
+        if (!$orderIds) {
+            return;
+        }
+        $connection =   $this->resourceConnection->getConnection();
+        $connection->update(
+            $this->resourceConnection->getTableName('sales_order'),
+            [self::SYNCED_TO_YOTPO_ORDER_COLUMN => '0'],
+            [
+                'store_id' => $storeId,
+                'entity_id IN (?) ' => $orderIds
+            ]
+        );
+    }
+
+    /**
+     * @param array <int> $orderIds
+     * @return void
+     */
+    public function cleanUpSyncTable($orderIds)
+    {
+        $connection  = $this->resourceConnection->getConnection();
+        $tableName = $this->resourceConnection->getTableName(self::ORDERS_SYNC_TABLE);
+        $whereConditions = [
+            $connection->quoteInto('order_id IN (?)', $orderIds)
+        ];
+        $connection->delete($tableName, $whereConditions);
+    }
+}

--- a/Model/Sync/ResetEntitiesSync.php
+++ b/Model/Sync/ResetEntitiesSync.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Yotpo\Core\Model\Sync;
+
+use Yotpo\Core\Model\Sync\Reset\Catalog;
+use Yotpo\Core\Model\Sync\Reset\Customers;
+use Yotpo\Core\Model\Sync\Reset\Orders;
+
+class ResetEntitiesSync
+{
+    /**
+     * @var Catalog
+     */
+    protected $catalogReset;
+
+    /**
+     * @var Customers
+     */
+    protected $customersReset;
+
+    /**
+     * @var Orders
+     */
+    protected $ordersReset;
+
+    /**
+     * @param Catalog $catalogReset
+     * @param Customers $customersReset
+     * @param Orders $ordersReset
+     */
+    public function __construct(
+        Catalog $catalogReset,
+        Customers $customersReset,
+        Orders $ordersReset
+    ) {
+        $this->catalogReset = $catalogReset;
+        $this->customersReset = $customersReset;
+        $this->ordersReset = $ordersReset;
+    }
+
+    /**
+     * @param int $storeId
+     * @return void
+     */
+    public function resetSync($storeId)
+    {
+        $this->resetCatalogSync($storeId);
+        $this->resetCustomersSync($storeId);
+        $this->resetOrdersSync($storeId);
+    }
+
+    /**
+     * @param int $storeId
+     * @return void
+     */
+    public function resetCatalogSync($storeId)
+    {
+        $this->catalogReset->resetSync($storeId);
+    }
+
+    /**
+     * @param int $storeId
+     * @return void
+     */
+    public function resetOrdersSync($storeId)
+    {
+        $this->ordersReset->resetSync($storeId);
+    }
+
+    /**
+     * @param int $storeId
+     * @return void
+     */
+    public function resetCustomersSync($storeId)
+    {
+        $this->customersReset->resetSync($storeId);
+    }
+}

--- a/Observer/Config/Main.php
+++ b/Observer/Config/Main.php
@@ -11,7 +11,7 @@ class Main
     /**
      * retrieve scope details
      * @param Observer $observer
-     * @return string[]
+     * @return array <mixed>
      */
     public function getScopes(Observer $observer): array
     {
@@ -32,7 +32,7 @@ class Main
         }
         $return['scope'] = $scope;
         $return['scopes'] = $scopes;
-        $return['scope_id'] = $scopeId;
+        $return['scope_id'] = (int) $scopeId;
         return $return;
     }
 }

--- a/Observer/Config/Save.php
+++ b/Observer/Config/Save.php
@@ -12,6 +12,7 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Store\Model\ScopeInterface;
 use Yotpo\Core\Model\Api\Token as YotpoApi;
+use Yotpo\Core\Model\Sync\ResetEntitiesSync as SyncReset;
 use Yotpo\Reviews\Model\Config as YotpoConfig;
 
 /**
@@ -51,6 +52,11 @@ class Save extends Main implements ObserverInterface
     protected $cronFrequency;
 
     /**
+     * @var SyncReset
+     */
+    protected $syncReset;
+
+    /**
      * Save constructor.
      * @param TypeListInterface $cacheTypeList
      * @param ReinitableConfigInterface $config
@@ -58,6 +64,7 @@ class Save extends Main implements ObserverInterface
      * @param YotpoApi $yotpoApi
      * @param CatalogMapping $catalogMapping
      * @param CronFrequency $cronFrequency
+     * @param SyncReset $syncReset
      */
     public function __construct(
         TypeListInterface $cacheTypeList,
@@ -65,7 +72,8 @@ class Save extends Main implements ObserverInterface
         YotpoConfig $yotpoConfig,
         YotpoApi $yotpoApi,
         CatalogMapping $catalogMapping,
-        CronFrequency $cronFrequency
+        CronFrequency $cronFrequency,
+        SyncReset $syncReset
     ) {
         $this->cacheTypeList = $cacheTypeList;
         $this->appConfig = $config;
@@ -73,6 +81,7 @@ class Save extends Main implements ObserverInterface
         $this->yotpoApi = $yotpoApi;
         $this->catalogMapping = $catalogMapping;
         $this->cronFrequency = $cronFrequency;
+        $this->syncReset = $syncReset;
     }
 
     /**
@@ -98,40 +107,44 @@ class Save extends Main implements ObserverInterface
     public function doYotpoApiKeyValidation(Observer $observer)
     {
         $changedPaths = (array)$observer->getEvent()->getChangedPaths();
-        if ($changedPaths && $this->isYotpoKeysChanged($changedPaths)) {
-            $this->cacheTypeList->cleanType(Config::TYPE_IDENTIFIER);
-            $this->appConfig->reinit();
+        if ($changedPaths) {
             $scopeDetails = $this->getScopes($observer);
-            $scopeId = (int) $scopeDetails['scope_id'];
-            $scope = $scopeDetails['scope'];
-            $scopes = $scopeDetails['scopes'];
+            $scopeId = $scopeDetails['scope_id'];
+            if ($this->isYotpoSettingsChanged($changedPaths)) {
+                $this->cacheTypeList->cleanType(Config::TYPE_IDENTIFIER);
+                $this->appConfig->reinit();
+                $scope = $scopeDetails['scope'];
+                $scopes = $scopeDetails['scopes'];
+                $appKey = $this->yotpoConfig->getAppKey($scopeId, $scope);
 
-            $appKey = $this->yotpoConfig->getAppKey($scopeId, $scope);
+                if ($scope !== ScopeInterface::SCOPE_STORE && !$this->yotpoConfig->isSingleStoreMode()) {
+                    $this->resetStoreCredentials($scopeId, $scopes);
+                    return true;
+                }
 
-            if ($scope !== ScopeInterface::SCOPE_STORE && !$this->yotpoConfig->isSingleStoreMode()) {
-                $this->resetStoreCredentials($scopeId, $scopes);
-                return true;
-            }
-
-            //Check if appKey is unique:
-            if ($appKey) {
-                foreach ((array) $this->yotpoConfig->getAllStoreIds() as $key => $storeId) {
-                    if (($scopeId && $storeId != $scopeId) && $this->yotpoConfig->getAppKey($storeId) === $appKey) {
-                        $this->resetStoreCredentials($scopeId, $scopes);
-                        throw new AlreadyExistsException(__(
-                            "The APP KEY you've entered is already in use by another store on this system.
-                            Note that Yotpo requires a unique set of APP KEY & SECRET for each store."
-                        ));
+                //Check if appKey is unique:
+                if ($scopeId && $appKey) {
+                    foreach ((array) $this->yotpoConfig->getAllStoreIds() as $storeId) {
+                        if (($storeId != $scopeId) && $this->yotpoConfig->getAppKey($storeId) === $appKey) {
+                            $this->resetStoreCredentials($scopeId, $scopes);
+                            throw new AlreadyExistsException(__(
+                                "The APP KEY you've entered is already in use by another store on this system.
+                                Note that Yotpo requires a unique set of APP KEY & SECRET for each store."
+                            ));
+                        }
                     }
                 }
-            }
 
-            if ($this->yotpoConfig->isEnabled($scopeId, $scope) &&
-                !($this->yotpoApi->createAuthToken($scopeId, $scope))) {
-                $this->resetStoreCredentials($scopeId, $scopes);
-                throw new AlreadyExistsException(__(
-                    "Please make sure the APP KEY and SECRET you've entered are correct"
-                ));
+                if ($this->yotpoConfig->isEnabled($scopeId, $scope) &&
+                    !($this->yotpoApi->createAuthToken($scopeId, $scope))) {
+                    $this->resetStoreCredentials($scopeId, $scopes);
+                    throw new AlreadyExistsException(__(
+                        "Please make sure the APP KEY and SECRET you've entered are correct"
+                    ));
+                }
+            }
+            if ($scopeId && $this->isYotpoAppKeyChanged($changedPaths)) {
+                $this->syncReset->resetSync($scopeId);
             }
         }
     }
@@ -155,13 +168,35 @@ class Save extends Main implements ObserverInterface
      * @param array <string> $changedPaths
      * @return bool
      */
-    public function isYotpoKeysChanged($changedPaths = [])
+    public function isYotpoSettingsChanged($changedPaths = [])
     {
         $yotpoKeyPaths = ['app_key', 'secret', 'yotpo_active'];
+        $commonPaths = $this->getChangedYotpoPaths($changedPaths, $yotpoKeyPaths);
+        return (bool)$commonPaths;
+    }
+
+    /**
+     * @param array <string> $changedPaths
+     * @return bool
+     */
+    public function isYotpoAppKeyChanged($changedPaths = [])
+    {
+        $yotpoKeyPaths = ['app_key'];
+        $commonPaths = $this->getChangedYotpoPaths($changedPaths, $yotpoKeyPaths);
+        return (bool)$commonPaths;
+    }
+
+    /**
+     * @param array <string> $changedPaths
+     * @param array <string> $keyPathsToCompare
+     * @return array <mixed>
+     */
+    public function getChangedYotpoPaths($changedPaths, $keyPathsToCompare)
+    {
         $pathsToCheck = [];
-        foreach ($yotpoKeyPaths as $yotpoPath) {
-            $pathsToCheck[] = $this->yotpoConfig->getConfigPath($yotpoPath);
+        foreach ($keyPathsToCompare as $keyPath) {
+            $pathsToCheck[] = $this->yotpoConfig->getConfigPath($keyPath);
         }
-        return (bool)array_intersect($pathsToCheck, $changedPaths);
+        return array_intersect($pathsToCheck, $changedPaths);
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -95,6 +95,7 @@
         <arguments>
             <argument name="commands" xsi:type="array">
                 <item name="yotpoResync" xsi:type="object">Yotpo\Core\Console\Command\RetryYotpoSync</item>
+                <item name="yotpoResetSync" xsi:type="object">Yotpo\Core\Console\Command\ResetYotpoSync</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
From #104.
Together with https://github.com/YotpoLtd/magento2-module-messaging/pull/78.

## Description
Whenever an app key changes, the sync data should be cleared.
This is in order for the store data to be re-synced into the newly configured store.

## Solution
Sync data is cleared via the following methods:
1. CLI command
2. Changing store's Yotpo store ID

## CLI Command Usage
`bin/magento yotpo:resetsync --entity={entity_type}`

Available entity types:
- order
- catalog
- customer
- all