### PR TITLE
COR-2092 Magento 2.4.4 Support

### DIFF
--- a/Http/Yclient.php
+++ b/Http/Yclient.php
@@ -102,7 +102,7 @@ class Yclient
             $logData[] = 'API URL = ' . $baseUrl . $uriEndpoint;
             $logData[] = 'API METHOD = ' . $requestMethod;
             $logData[] = $options;
-            $this->yotpoApiLogger->info($logMessage, $logData);
+            $this->yotpoApiLogger->infoLog($logMessage, $logData);
             $logData = [];
             $response = $client->request(
                 $requestMethod,
@@ -114,7 +114,7 @@ class Yclient
             $responseContent = $responseBody->getContents();
             $responseBody->rewind();
             $logData[] = 'response = ' . $responseContent;
-            $this->yotpoApiLogger->info($logMessage, $logData);
+            $this->yotpoApiLogger->infoLog($logMessage, $logData);
         } catch (GuzzleException $exception) {
             $exceptionData = [];
             $exceptionMessage = 'API Error';
@@ -135,7 +135,7 @@ class Yclient
             }
             $exceptionData[] = 'response code = ' . $exceptionCode;
             $exceptionData[] = 'response = ' . $exception->getMessage();
-            $this->yotpoApiLogger->info($exceptionMessage, $exceptionData);
+            $this->yotpoApiLogger->infoLog($exceptionMessage, $exceptionData);
         }
         return $response;
     }
@@ -217,7 +217,7 @@ class Yclient
             $responseBody = $response->getBody();
             $responseReason = $response->getReasonPhrase();
             $responseContent = $responseBody->getContents();
-            $this->yotpoApiLogger->info($responseContent, []);
+            $this->yotpoApiLogger->infoLog($responseContent, []);
             $responseBody->rewind();
             $responseObject = new DataObject();
             $responseObject->setData('status', $status);

--- a/Model/Logger/Main.php
+++ b/Model/Logger/Main.php
@@ -44,9 +44,9 @@ class Main extends \Monolog\Logger
      *
      * @param  string $message The log message
      * @param  array  <mixed> $context The log context
-     * @return bool   Whether the record has been processed
+     * @return void|bool
      */
-    public function info($message, array $context = []): bool
+    public function infoLog($message, array $context = [])
     {
         $message = self::LOG_PREFIX . $message;
         if ($this->isDebugEnabled()) {
@@ -61,9 +61,9 @@ class Main extends \Monolog\Logger
      *
      * @param string $message
      * @param array<mixed> $context
-     * @return bool
+     * @return void|bool
      */
-    public function error($message, array $context = []): bool
+    public function errorLog($message, array $context = [])
     {
         $this->logSystemInfo();
         $message = self::LOG_PREFIX . $message;

--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -277,7 +277,7 @@ class Data extends Main
                 try {
                     $this->getChildOptions($item);
                 } catch (\Exception $e) {
-                    $this->logger->info('error in mergeProductOptions() :  ' . $e->getMessage(), []);
+                    $this->logger->infoLog('error in mergeProductOptions() :  ' . $e->getMessage(), []);
                 }
             }
         }
@@ -346,7 +346,7 @@ class Data extends Main
                     $syncItems[$key]['options'] = $configOptions;
                 }
             } catch (\Exception $e) {
-                $this->logger->info(
+                $this->logger->infoLog(
                     __(
                         'Exception raised within prepareOptions - $key: %1, $id: %2 Exception Message: %3',
                         $key,
@@ -416,7 +416,7 @@ class Data extends Main
                     unset($itemArray[$key]);
                 }
             } catch (\Exception $e) {
-                $this->logger->info(
+                $this->logger->infoLog(
                     __(
                         'Exception raised within attributeMapping - $key: %1, $attr: %2 Exception Message: %3',
                         $key,
@@ -604,7 +604,7 @@ class Data extends Main
             if ($product->getTypeId() != $configurableProductTypeCode) {
                 $keysToDeleteFromMap = array_keys($filteredProductIds, $product->getId());
                 foreach ($keysToDeleteFromMap as $keyToDeleteFromMap) {
-                    $this->logger->info(
+                    $this->logger->infoLog(
                         __(
                             'A non-configurable product is being filtered - Key: %1, Product ID: %2',
                             $keyToDeleteFromMap,

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -219,10 +219,11 @@ class Processor extends Main
                     $unSyncedStoreIds[] = $storeId;
                     $this->yotpoCatalogLogger->infoLog(
                         __(
-                            'Product Sync has stopped with exception: %1, Magento Store ID: %2, Name: %3',
+                            'Product Sync has stopped with exception: %1, Magento Store ID: %2, Name: %3, Trace: %4',
                             $e->getMessage(),
                             $storeId,
-                            $this->coreConfig->getStoreName($storeId)
+                            $this->coreConfig->getStoreName($storeId),
+                            $e->getTraceAsString()
                         )
                     );
                 }

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -145,7 +145,7 @@ class Processor extends Main
                     $disabled = false;
                     if ($this->coreConfig->isSyncResetInProgress($storeId, 'catalog')) {
                         $disabled = true;
-                        $this->yotpoCatalogLogger->info(
+                        $this->yotpoCatalogLogger->infoLog(
                             __(
                                 'Product sync is skipped because catalog sync reset is in progress
                          - Magento Store ID: %1, Name: %2',
@@ -156,7 +156,7 @@ class Processor extends Main
                     }
                     if (!$this->coreConfig->isEnabled()) {
                         $disabled = true;
-                        $this->yotpoCatalogLogger->info(
+                        $this->yotpoCatalogLogger->infoLog(
                             __(
                                 'Product Sync - Yotpo is Disabled - Magento Store ID: %1, Name: %2',
                                 $storeId,
@@ -171,7 +171,7 @@ class Processor extends Main
                     }
                     if ($this->isSyncingAsMainEntity() && !$this->coreConfig->isCatalogSyncActive()) {
                         $disabled = true;
-                        $this->yotpoCatalogLogger->info(
+                        $this->yotpoCatalogLogger->infoLog(
                             __(
                                 'Product Sync - Disabled - Magento Store ID: %1, Name: %2',
                                 $storeId,
@@ -189,7 +189,7 @@ class Processor extends Main
                         continue;
                     }
                     $this->productSyncLimit = $this->coreConfig->getConfig('product_sync_limit');
-                    $this->yotpoCatalogLogger->info(
+                    $this->yotpoCatalogLogger->infoLog(
                         __(
                             'Product Sync - Start - Magento Magento Store ID: %1, Name: %2',
                             $storeId,
@@ -211,13 +211,13 @@ class Processor extends Main
                             $unSyncedStoreIds[] = $storeId;
                         }
                     } else {
-                        $this->yotpoCatalogLogger->info(
+                        $this->yotpoCatalogLogger->infoLog(
                             __('Product Sync - Stopped - Magento Store ID: %1', $storeId)
                         );
                     }
                 } catch (\Exception $e) {
                     $unSyncedStoreIds[] = $storeId;
-                    $this->yotpoCatalogLogger->info(
+                    $this->yotpoCatalogLogger->infoLog(
                         __(
                             'Product Sync has stopped with exception: %1, Magento Store ID: %2, Name: %3',
                             $e->getMessage(),
@@ -235,7 +235,7 @@ class Processor extends Main
                 return true;
             }
         } catch (\Exception $e) {
-            $this->yotpoCatalogLogger->info(
+            $this->yotpoCatalogLogger->infoLog(
                 __('Catalog sync::process() - Exception: ', [$e->getTraceAsString()])
             );
             return false;
@@ -252,7 +252,7 @@ class Processor extends Main
     public function syncItems($collectionItems, $storeId, $isVisibleVariantsSync = false)
     {
         if (!count($collectionItems)) {
-            $this->yotpoCatalogLogger->info(
+            $this->yotpoCatalogLogger->infoLog(
                 __(
                     'Product Sync complete : No Data, Magento Store ID: %1, Name: %2',
                     $storeId,
@@ -295,7 +295,7 @@ class Processor extends Main
                     if (!$this->isProductParentYotpoIdFound($yotpoSyncTableItemsData, $parentItemId)) {
                         $parentProductData = $this->getCollectionForSync([$parentItemId])->getItems();
                         if (!$parentProductData) {
-                            $this->yotpoCatalogLogger->info(
+                            $this->yotpoCatalogLogger->infoLog(
                                 __(
                                     'Skipping variant sync, parent product not found - Store ID: %1, Store Name: %2, Item Entity ID: %3, Parent Entity ID: %4',
                                     $storeId,
@@ -326,7 +326,7 @@ class Processor extends Main
                         $parentProductYotpoId = $yotpoSyncTableItemsData[$parentItemId]['yotpo_id'];
                         $yotpoSyncTableItemsData[$itemEntityId]['yotpo_id_parent'] = $parentProductYotpoId;
 
-                        $this->yotpoCatalogLogger->info(
+                        $this->yotpoCatalogLogger->infoLog(
                             __(
                                 'Yotpo ID of parent product changed - Store ID: %1, Store Name: %2, Parent Entity ID: %3, New Yotpo ID: %4',
                                 $storeId,
@@ -352,7 +352,7 @@ class Processor extends Main
                     }
                 }
 
-                $this->yotpoCatalogLogger->info(
+                $this->yotpoCatalogLogger->infoLog(
                     __(
                         'Data ready to sync - Method: %1 - Magento Store ID: %2, Name: %3',
                         $apiRequestParams['method'],
@@ -482,7 +482,7 @@ class Processor extends Main
             } catch (\Exception $e) {
                 $hasFailedCreatingAnyProduct = true;
                 $this->updateProductSyncAttribute($storeId, $itemRowId);
-                $this->yotpoCatalogLogger->info(
+                $this->yotpoCatalogLogger->infoLog(
                     __(
                         'error while syncing product, store_id: %1, product_id: %2. Exception: %3',
                         $storeId,
@@ -532,7 +532,7 @@ class Processor extends Main
         }
 
         if ($hasFailedCreatingAnyProduct) {
-            $this->yotpoCatalogLogger->info(
+            $this->yotpoCatalogLogger->infoLog(
                 __(
                     'API errors occurred while trying to create products -
                     Store ID: %1, Store Name: %2, Is Visible Variants Sync: %3',
@@ -587,7 +587,7 @@ class Processor extends Main
                     $this->productsSyncService->updateSyncTable($returnResponse['temp_sql']);
                 } catch (\Exception $e) {
                     $this->updateProductSyncAttribute($storeId, $itemId);
-                    $this->yotpoCatalogLogger->info(
+                    $this->yotpoCatalogLogger->infoLog(
                         __(
                             'Exception raised within processDeleteData - $itemId: %1, $itemData: %2 Exception Message: %3',
                             $itemId,
@@ -637,7 +637,7 @@ class Processor extends Main
                     $this->productsSyncService->updateSyncTable($returnResponse['temp_sql']);
                 } catch (\Exception $e) {
                     $this->updateProductSyncAttribute($storeId, $itemId);
-                    $this->yotpoCatalogLogger->info(
+                    $this->yotpoCatalogLogger->infoLog(
                         __(
                             'Exception raised within processUnAssignData - $itemId: %1, $itemData: %2 Exception Message: %3',
                             $itemId,
@@ -901,7 +901,7 @@ class Processor extends Main
      */
     private function forceParentProductSyncToYotpo($storeId, $itemEntityId, $parentItemId, $parentProductData, $yotpoSyncTableItemsData, $parentItemsIds, $yotpoFormatItemData)
     {
-        $this->yotpoCatalogLogger->info(
+        $this->yotpoCatalogLogger->infoLog(
             __(
                 'Start syncing parent product that does not exist in Yotpo - Store ID: %1, Store Name: %2, Item Entity ID: %3, Parent Entity ID: %4',
                 $storeId,
@@ -924,7 +924,7 @@ class Processor extends Main
         );
 
         if ($parentProductYotpoId) {
-            $this->yotpoCatalogLogger->info(
+            $this->yotpoCatalogLogger->infoLog(
                 __(
                     'Finished syncing parent product that does not exist in Yotpo - Store ID: %1, Store Name: %2, Parent Entity ID: %3, Yotpo ID: %4',
                     $storeId,
@@ -939,7 +939,7 @@ class Processor extends Main
                 'yotpo_id' => $parentProductYotpoId
             ];
         } else {
-            $this->yotpoCatalogLogger->info(
+            $this->yotpoCatalogLogger->infoLog(
                 __(
                     'Failed creating parent product for a variant - Store ID: %1, Store Name: %2, Parent Entity ID: %3, Yotpo ID: %4',
                     $storeId,
@@ -985,7 +985,7 @@ class Processor extends Main
         $apiRequestParams['yotpo_id'] = $responseObject['yotpo_id'];
 
         if ($response && !$response->getData(CoreConfig::YOTPO_SYNC_RESPONSE_IS_SUCCESS_KEY)) {
-            $this->yotpoCatalogLogger->info(
+            $this->yotpoCatalogLogger->infoLog(
                 __(
                     'Failed syncing missing variant parent product to Yotpo - Parent Entity ID: %1, Status Code: %2, Reason: %3',
                     $parentId,
@@ -1100,7 +1100,7 @@ class Processor extends Main
         $updatedParentYotpoId,
         $syncedToYotpoProductAttributeId
     ) {
-        $this->yotpoCatalogLogger->info(
+        $this->yotpoCatalogLogger->infoLog(
             __(
                 'Yotpo Parent Product ID changed, forcing variants re-sync. Store ID: %1, Entity ID: %2, Current Yotpo ID: %3, Updated Yotpo ID: %4',
                 $storeId,

--- a/Model/Sync/Catalog/Processor/CatalogRequestHandler.php
+++ b/Model/Sync/Catalog/Processor/CatalogRequestHandler.php
@@ -72,7 +72,7 @@ class CatalogRequestHandler
             try {
                 $yotpoProductId = $this->getYotpoItemIdFromItemEntityId($itemEntityId, 'products');
             } catch (UnexpectedValueException $e) {
-                $this->yotpoCatalogLogger->info(
+                $this->yotpoCatalogLogger->infoLog(
                     __(
                         'Failed getting Yotpo product ID from entity ID,
                         returning initial upsert response - Product Entity ID: %1',
@@ -110,7 +110,7 @@ class CatalogRequestHandler
                     $itemEntityId
                 );
             } catch (UnexpectedValueException $e) {
-                $this->yotpoCatalogLogger->info(
+                $this->yotpoCatalogLogger->infoLog(
                     __(
                         'Failed getting Yotpo variant ID from entity ID,
                         returning initial upsert response - Variant Entity ID: %1',

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -151,7 +151,7 @@ class Main extends AbstractJobs
             default:
                 $response = $this->coreSync->getEmptyResponse();
                 $storeId = $this->coreConfig->getStoreId();
-                $this->yotpoCatalogLogger->info(
+                $this->yotpoCatalogLogger->infoLog(
                     __(
                         'API request process failed due to a matching method was not found -
                         Magento Store ID: %1, Name: %2',
@@ -261,7 +261,7 @@ class Main extends AbstractJobs
             default:
                 $tempSqlArray = [];
                 $storeId = $this->coreConfig->getStoreId();
-                $this->yotpoCatalogLogger->info(
+                $this->yotpoCatalogLogger->infoLog(
                     __(
                         'API Response Process failed due to a matching method was not found
                         - Magento Store ID: %1, Name: %2',
@@ -306,7 +306,7 @@ class Main extends AbstractJobs
      */
     protected function writeSuccessLog($method, $storeId)
     {
-        $this->yotpoCatalogLogger->info(
+        $this->yotpoCatalogLogger->infoLog(
             __(
                 '%1 API ran successfully - Magento Store ID: %2, Name: %3',
                 $method,
@@ -326,7 +326,7 @@ class Main extends AbstractJobs
      */
     protected function writeFailedLog($method, $storeId)
     {
-        $this->yotpoCatalogLogger->info(
+        $this->yotpoCatalogLogger->infoLog(
             __(
                 '%1 API failed - Magento Store ID: %2, Name: %3',
                 $method,

--- a/Model/Sync/Catalog/Processor/Main.php
+++ b/Model/Sync/Catalog/Processor/Main.php
@@ -693,7 +693,7 @@ class Main extends AbstractJobs
             $storeId
         );
 
-        $productsSyncData = $connection->fetchAssoc($productsYotpoIdsQuery, 'product_id');
+        $productsSyncData = $connection->fetchAssoc($productsYotpoIdsQuery);
 
         $productIdsToYotpoIdsMap = [];
         foreach ($productsSyncData as $productId => $productSyncRecord) {

--- a/Model/Sync/Catalog/Services/ProductsSyncService.php
+++ b/Model/Sync/Catalog/Services/ProductsSyncService.php
@@ -73,7 +73,7 @@ class ProductsSyncService extends AbstractJobs
             'is_deleted = ?',
             0
         );
-        $items = $connection->fetchAssoc($select, 'product_id');
+        $items = $connection->fetchAssoc($select);
         return array_keys($items);
     }
 

--- a/Model/Sync/Catalog/YotpoResource.php
+++ b/Model/Sync/Catalog/YotpoResource.php
@@ -68,7 +68,7 @@ class YotpoResource
             $connection->quoteInto('yotpo.store_id = ?', $this->coreConfig->getStoreId())
         );
 
-        $items = $connection->fetchAssoc($select, []);
+        $items = $connection->fetchAssoc($select);
 
         $yotpoData = [];
         if ($items) {
@@ -103,7 +103,7 @@ class YotpoResource
             $limit
         );
 
-        return $connection->fetchAssoc($select, 'product_id');
+        return $connection->fetchAssoc($select);
     }
 
     /**
@@ -125,7 +125,7 @@ class YotpoResource
         )->limit(
             $limit
         );
-        return $connection->fetchAssoc($select, 'product_id');
+        return $connection->fetchAssoc($select);
     }
 
     /**
@@ -174,7 +174,7 @@ class YotpoResource
             $connection->quoteInto('link_type_id = ?', GroupedLink::LINK_TYPE_GROUPED)
         );
 
-        $items = $connection->fetchAssoc($select, 'product_id');
+        $items = $connection->fetchAssoc($select);
         $groupIds = [];
         foreach ($items as $item) {
             $groupIds[$item['product_id']] = $item['parent_id'];

--- a/Model/Sync/Category/Processor/Main.php
+++ b/Model/Sync/Category/Processor/Main.php
@@ -125,7 +125,7 @@ class Main extends AbstractJobs
             ->where('store_id=(?)', $storeId)
             ->where('yotpo_id > 0');
 
-        $categories = $connection->fetchAssoc($categories, []);
+        $categories = $connection->fetchAssoc($categories);
         foreach ($categories as $cat) {
             $return[$cat['category_id']] = $cat;
         }
@@ -424,7 +424,7 @@ class Main extends AbstractJobs
             $storeId
         );
 
-        $categoriesSyncData = $connection->fetchAssoc($categoryYotpoIdsQuery, 'category_id');
+        $categoriesSyncData = $connection->fetchAssoc($categoryYotpoIdsQuery);
 
         $categoryIdsToYotpoIdsMap = [];
         foreach ($categoriesSyncData as $categoryId => $categorySyncRecord) {
@@ -477,7 +477,7 @@ class Main extends AbstractJobs
             'category_id = ?',
             $categoryId
         );
-        $storesSyncedWithCategory = $connection->fetchAssoc($select, 'store_id');
+        $storesSyncedWithCategory = $connection->fetchAssoc($select);
 
         $storesSuccessfullySyncedWithCategory = [];
         foreach ($storesSyncedWithCategory as $storeId => $storeSyncedWithCategory) {

--- a/Model/Sync/Category/Processor/ProcessByCategory.php
+++ b/Model/Sync/Category/Processor/ProcessByCategory.php
@@ -106,7 +106,7 @@ class ProcessByCategory extends Main
                 }
                 $this->emulateFrontendArea($storeId);
                 if ($this->config->isSyncResetInProgress($storeId, 'catalog')) {
-                    $this->yotpoCoreCatalogLogger->info(
+                    $this->yotpoCoreCatalogLogger->infoLog(
                         __(
                             'Category sync is skipped because catalog sync
                              reset is in progress - Magento Store ID: %1, Name: %2',
@@ -118,7 +118,7 @@ class ProcessByCategory extends Main
                     continue;
                 }
                 if (!$this->config->isCatalogSyncActive()) {
-                    $this->yotpoCoreCatalogLogger->info(
+                    $this->yotpoCoreCatalogLogger->infoLog(
                         __(
                             'Catalog Sync is Disabled - Magento Store ID: %1, Name: %2',
                             $storeId,
@@ -128,7 +128,7 @@ class ProcessByCategory extends Main
                     $this->stopEnvironmentEmulation();
                     continue;
                 }
-                $this->yotpoCoreCatalogLogger->info(
+                $this->yotpoCoreCatalogLogger->infoLog(
                     sprintf(
                         'Category Sync - Start - Magento Store ID: %s, Name: %s',
                         $storeId,
@@ -138,7 +138,7 @@ class ProcessByCategory extends Main
                 $retryCategoryIds = $retryCategories[$storeId] ?? $retryCategories;
                 $this->processEntities($retryCategoryIds);
                 $this->stopEnvironmentEmulation();
-                $this->yotpoCoreCatalogLogger->info(
+                $this->yotpoCoreCatalogLogger->infoLog(
                     sprintf(
                         'Category Sync - Finish - Magento Store ID: %s, Name: %s',
                         $storeId,
@@ -192,7 +192,7 @@ class ProcessByCategory extends Main
         $magentoCategories = [];
         foreach ($collection->getItems() as $category) {
             if ($this->config->isSyncResetInProgress($storeId, 'catalog')) {
-                $this->yotpoCoreCatalogLogger->info(
+                $this->yotpoCoreCatalogLogger->infoLog(
                     __(
                         'Category sync is skipped because catalog sync
                              reset is in progress - Magento Store ID: %1, Name: %2',
@@ -208,7 +208,7 @@ class ProcessByCategory extends Main
         $categoriesByPath = $this->getCategoriesFromPathNames(array_values($magentoCategories));
         $yotpoSyncedCategories = $this->getYotpoSyncedCategories(array_keys($magentoCategories));
         if (!$magentoCategories) {
-            $this->yotpoCoreCatalogLogger->info(
+            $this->yotpoCoreCatalogLogger->infoLog(
                 'Category Sync - There are no items left to sync'
             );
         }
@@ -279,7 +279,7 @@ class ProcessByCategory extends Main
                         $categoryIdToUpdate = $magentoCategory->getRowId() ?: $categoryId;
                         $this->updateCategoryAttribute($categoryIdToUpdate);
                     }
-                    $this->yotpoCoreCatalogLogger->info(
+                    $this->yotpoCoreCatalogLogger->infoLog(
                         sprintf('Category Sync - sync success - Category ID: %s', $categoryId)
                     );
                     if ($this->isCommandLineSync) {
@@ -290,7 +290,7 @@ class ProcessByCategory extends Main
             } catch (\Exception $e) {
                 $magentoCategoryId =  $magentoCategory->getId();
                 $this->updateCategoryAttribute($magentoCategoryId);
-                $this->yotpoCoreCatalogLogger->info(
+                $this->yotpoCoreCatalogLogger->infoLog(
                     __(
                         'Exception raised within processEntities - $magentoCategoryId: %1, Exception Message: %2',
                         $magentoCategoryId,
@@ -316,7 +316,7 @@ class ProcessByCategory extends Main
                     $this->updateCategoryAttribute($categoryIdToUpdate);
                 }
             } catch (\Exception $e) {
-                $this->yotpoCoreCatalogLogger->info(
+                $this->yotpoCoreCatalogLogger->infoLog(
                     __(
                         'Exception raised within processEntities - $mageCatId: %1, $yotpoId: %2, Exception Message: %3',
                         $mageCatId,
@@ -328,7 +328,7 @@ class ProcessByCategory extends Main
         }
 
         $this->deleteCollections();
-        $this->yotpoCoreCatalogLogger->info(
+        $this->yotpoCoreCatalogLogger->infoLog(
             sprintf(
                 'Category Sync - sync completed - Magento Store ID: %s, Name: %s',
                 $storeId,
@@ -345,7 +345,7 @@ class ProcessByCategory extends Main
     public function deleteCollections()
     {
         $storeId = $this->config->getStoreId();
-        $this->yotpoCoreCatalogLogger->info(
+        $this->yotpoCoreCatalogLogger->infoLog(
             __(
                 'Category Sync - Starting assigning deleted categories for store - Magento Store ID: %1, Name: %2',
                 $storeId,
@@ -356,7 +356,7 @@ class ProcessByCategory extends Main
         foreach ($categoriesToDelete as $category) {
             $categoryId = $category['category_id'];
             try {
-                $this->yotpoCoreCatalogLogger->info(
+                $this->yotpoCoreCatalogLogger->infoLog(
                     __(
                         'Category Sync - Deleting category - Magento Store ID: %1, Name: %2, Category ID - %3',
                         $storeId,
@@ -375,7 +375,7 @@ class ProcessByCategory extends Main
                 }
                 $this->updateYotpoTblForDeletedCategories($categoryId);
             } catch (\Exception $e) {
-                $this->yotpoCoreCatalogLogger->info(
+                $this->yotpoCoreCatalogLogger->infoLog(
                     __(
                         'Exception raised within deleteCollections - $categoryId: %1, Exception Message: %2',
                         $categoryId,
@@ -385,7 +385,7 @@ class ProcessByCategory extends Main
             }
         }
 
-        $this->yotpoCoreCatalogLogger->info(
+        $this->yotpoCoreCatalogLogger->infoLog(
             __(
                 'Category Sync - Finished assigning deleted categories for store - Magento Store ID: %1, Name: %2',
                 $storeId,

--- a/Model/Sync/Category/Processor/ProcessByProduct.php
+++ b/Model/Sync/Category/Processor/ProcessByProduct.php
@@ -20,11 +20,11 @@ class ProcessByProduct extends Main
      */
     public function process(array $productItems)
     {
-        $this->yotpoCoreCatalogLogger->info('Category Sync - Process categories by product - START ');
+        $this->yotpoCoreCatalogLogger->infoLog('Category Sync - Process categories by product - START ');
 
         foreach ($productItems as $productItem) {
             $productId = $productItem->getId();
-            $this->yotpoCoreCatalogLogger->info(
+            $this->yotpoCoreCatalogLogger->infoLog(
                 __(
                     'Product Sync - Setting product collections sync for product ID %1',
                     $productId

--- a/Model/Sync/CollectionsProducts/Processor.php
+++ b/Model/Sync/CollectionsProducts/Processor.php
@@ -126,7 +126,7 @@ class Processor extends AbstractJobs
             try {
                 $this->emulateFrontendArea($storeId);
                 if (!$this->shouldSyncCollectionsProducts()) {
-                    $this->catalogLogger->info(
+                    $this->catalogLogger->infoLog(
                         __(
                             'Collections Products Sync -
                             Sync for store is disabled -
@@ -139,7 +139,7 @@ class Processor extends AbstractJobs
                     continue;
                 }
 
-                $this->catalogLogger->info(
+                $this->catalogLogger->infoLog(
                     __(
                         'Collections Products Sync -
                         Starting sync for store -
@@ -165,7 +165,7 @@ class Processor extends AbstractJobs
                 $this->syncCollectionsProductsEntitiesToYotpo($enrichedCollectionsProductsEntitiesToSync, $storeId);
                 $this->logFinishedCollectionsProductsSync($storeId);
             } catch (Exception $exception) {
-                $this->catalogLogger->info(
+                $this->catalogLogger->infoLog(
                     __(
                         'Collections Products Sync -
                         Stopped sync for store -
@@ -284,7 +284,7 @@ class Processor extends AbstractJobs
             $collectionProductEntityToSync
         );
 
-        $this->catalogLogger->info(
+        $this->catalogLogger->infoLog(
             __(
                 'Collections Products Sync - Synced Collection Product to Yotpo successfully -
                      Magento Store ID: %1
@@ -305,7 +305,7 @@ class Processor extends AbstractJobs
      */
     private function logFinishedCollectionsProductsSync($storeId)
     {
-        $this->catalogLogger->info(
+        $this->catalogLogger->infoLog(
             __(
                 'Collections Products Sync - Finished sync for store - Magento Store ID: %1, Magento Store Name: %2',
                 $storeId,
@@ -418,7 +418,7 @@ class Processor extends AbstractJobs
                     $this->setAsSuccessfulCollectionProductSync($storeId, $enrichedCollectionProductEntityToSync);
                 }
             } catch (Exception $exception) {
-                $this->catalogLogger->info(
+                $this->catalogLogger->infoLog(
                     __(
                         'Collections Products Sync - Failed syncing Collection Product entity to Yotpo -
                             Magento Store ID: %1,

--- a/Model/Sync/CollectionsProducts/Services/CollectionsProductsService.php
+++ b/Model/Sync/CollectionsProducts/Services/CollectionsProductsService.php
@@ -98,7 +98,7 @@ class CollectionsProductsService extends AbstractJobs
             $categoryId
         );
 
-        $categoryProductsIdsMap = $connection->fetchAssoc($categoryProductsQuery, 'magento_product_id');
+        $categoryProductsIdsMap = $connection->fetchAssoc($categoryProductsQuery);
         return array_keys($categoryProductsIdsMap);
     }
 
@@ -118,7 +118,7 @@ class CollectionsProductsService extends AbstractJobs
             $productId
         );
 
-        $categoryProductsIdsMap = $connection->fetchAssoc($categoryProductsQuery, 'magento_category_id');
+        $categoryProductsIdsMap = $connection->fetchAssoc($categoryProductsQuery);
         return array_keys($categoryProductsIdsMap);
     }
 

--- a/Model/Sync/Data/Main.php
+++ b/Model/Sync/Data/Main.php
@@ -80,7 +80,7 @@ class Main
             ->from($table, ['product_id', 'yotpo_id', 'yotpo_id_parent', 'visible_variant_yotpo_id'])
             ->where('product_id IN(?) ', $productIds)
             ->where('store_id=(?)', $storeId);
-        $products = $connection->fetchAssoc($products, []);
+        $products = $connection->fetchAssoc($products);
 
         $existingProductIds = [];
         foreach ($products as $product) {
@@ -122,7 +122,7 @@ class Main
             ->where('product_id IN(?) ', $productIds)
             ->where('yotpo_id_parent != ?', 0)
             ->where('store_id=(?)', $storeId);
-        $products = $connection->fetchAssoc($products, []);
+        $products = $connection->fetchAssoc($products);
         $yotpoIds = [];
         foreach ($products as $product) {
             if ($product['yotpo_id_parent']) {

--- a/Model/Sync/Metadata/Processor.php
+++ b/Model/Sync/Metadata/Processor.php
@@ -75,7 +75,7 @@ class Processor extends AbstractJobs
             try {
                 $this->emulateFrontendArea($storeId);
                 if (!$this->yotpoConfig->isEnabled()) {
-                    $this->logger->info(
+                    $this->logger->infoLog(
                         __(
                             'Updating Metadata is disabled. Skipping for Magento Store ID: %1, Name: %2',
                             $storeId,
@@ -84,7 +84,7 @@ class Processor extends AbstractJobs
                     );
                     continue;
                 }
-                $this->logger->info(
+                $this->logger->infoLog(
                     __(
                         'Starting updating Metadata for Magento Store ID: %1, Name: %2',
                         $storeId,
@@ -101,7 +101,7 @@ class Processor extends AbstractJobs
                     $metadataDataToSync
                 );
                 if ($response[$this::SYNC_RESPONSE_IS_SUCCESS_KEY]) {
-                    $this->logger->info(
+                    $this->logger->infoLog(
                         __(
                             'Finished updating Metadata successfully for Magento Store ID: %1, Name: %2',
                             $storeId,
@@ -110,7 +110,7 @@ class Processor extends AbstractJobs
                     );
                 }
             } catch (\Exception $exception) {
-                $this->logger->info(
+                $this->logger->infoLog(
                     __(
                         'Error occurred when updating Metadata,
                         got Exception on Magento Store ID: %1,

--- a/Model/Sync/Orders/AbstractData.php
+++ b/Model/Sync/Orders/AbstractData.php
@@ -351,7 +351,7 @@ class AbstractData extends Main
                         $this->shipmentsCollection[$shipment->getOrderId()][] = $shipment;
                     } catch (\Exception $e) {
                         $orderId = method_exists($shipment, 'getOrderId') ? $shipment->getOrderId() : null;
-                        $this->yotpoOrdersLogger->info(
+                        $this->yotpoOrdersLogger->infoLog(
                             __(
                                 'Exception raised within prepareShipmentStatuses - orderId: %1, Exception Message: %2',
                                 $orderId,
@@ -362,7 +362,7 @@ class AbstractData extends Main
                 }
             }
         } catch (\Exception $e) {
-            $this->yotpoOrdersLogger->info(' Exception raised within prepareShipmentStatuses() :  ' . $e->getMessage(), []);
+            $this->yotpoOrdersLogger->infoLog(' Exception raised within prepareShipmentStatuses() :  ' . $e->getMessage(), []);
         }
     }
 
@@ -408,10 +408,10 @@ class AbstractData extends Main
                     }
                 }
             } catch (NoSuchEntityException $e) {
-                $this->yotpoOrdersLogger->info('Orders sync::getYotpoShipmentStatus() - NoSuchEntityException: ' .
+                $this->yotpoOrdersLogger->infoLog('Orders sync::getYotpoShipmentStatus() - NoSuchEntityException: ' .
                     $e->getMessage(), []);
             } catch (LocalizedException $e) {
-                $this->yotpoOrdersLogger->info('Orders sync::getYotpoShipmentStatus() - LocalizedException: ' .
+                $this->yotpoOrdersLogger->infoLog('Orders sync::getYotpoShipmentStatus() - LocalizedException: ' .
                     $e->getMessage(), []);
             }
         }
@@ -459,7 +459,7 @@ class AbstractData extends Main
                 }
             }
         } catch (\Exception $e) {
-            $this->yotpoOrdersLogger->info('Exception raised within prepareCouponCodes' . $e->getMessage(), []);
+            $this->yotpoOrdersLogger->infoLog('Exception raised within prepareCouponCodes' . $e->getMessage(), []);
         }
     }
 
@@ -531,7 +531,7 @@ class AbstractData extends Main
                         $this->customersAttributeCollection[$customer->getId()] = $customAttributeValue;
                     } catch (\Exception $e) {
                         $customerId = method_exists($customer, 'getId') ? $customer->getId() : null;
-                        $this->yotpoOrdersLogger->info(
+                        $this->yotpoOrdersLogger->infoLog(
                             __(
                                 'Exception raised within prepareShipmentStatuses - customerId: %1, Exception Message: %2',
                                 $customerId,
@@ -541,7 +541,7 @@ class AbstractData extends Main
                     }
                 }
             } catch (\Exception $e) {
-                $this->yotpoOrdersLogger->info(' prepareCustomAttributes() :  ' . $e->getMessage(), []);
+                $this->yotpoOrdersLogger->infoLog(' prepareCustomAttributes() :  ' . $e->getMessage(), []);
             }
         }
     }
@@ -598,7 +598,7 @@ class AbstractData extends Main
                         /** @phpstan-ignore-line */
                     } catch (\Exception $e) {
                         $orderId = method_exists($order, 'getEntityId') ? $order->getEntityId() : null;
-                        $this->yotpoOrdersLogger->info(
+                        $this->yotpoOrdersLogger->infoLog(
                             __(
                                 'Exception raised within prepareGuestUsersCustomAttributes - orderId: %1, Exception Message: %2',
                                 $orderId,
@@ -609,7 +609,7 @@ class AbstractData extends Main
                 }
             }
         } catch (\Exception $e) {
-            $this->yotpoOrdersLogger->info(' prepareGuestUsersCustomAttributes() :  ' . $e->getMessage(), []);
+            $this->yotpoOrdersLogger->infoLog(' prepareGuestUsersCustomAttributes() :  ' . $e->getMessage(), []);
         }
     }
 

--- a/Model/Sync/Orders/Data.php
+++ b/Model/Sync/Orders/Data.php
@@ -240,7 +240,7 @@ class Data extends AbstractData
                     $this->shipOrderItems[$orderItem->getId()] = $orderItem;
 
                     if (!($product && $product->getId())) {
-                        $this->yotpoOrdersLogger->info('Orders sync::prepareLineItems()
+                        $this->yotpoOrdersLogger->infoLog('Orders sync::prepareLineItems()
                         - Product not found for order: ' . $order->getEntityId(), []);
                         continue;
                     }
@@ -273,12 +273,12 @@ class Data extends AbstractData
                         }
                     }
                 } catch (\Exception $e) {
-                    $this->yotpoOrdersLogger->info('Orders sync::prepareLineItems() - exception for orderId: '.
+                    $this->yotpoOrdersLogger->infoLog('Orders sync::prepareLineItems() - exception for orderId: '.
                         $order->getId() . ' ' . $e->getMessage(), []);
                 }
             }
         } catch (\Exception $e) {
-            $this->yotpoOrdersLogger->info('Orders sync::prepareLineItems() - exception: for orderId: ' .
+            $this->yotpoOrdersLogger->infoLog('Orders sync::prepareLineItems() - exception: for orderId: ' .
                 $order->getId(). ' ' .$e->getMessage(), []);
         }
         return $lineItems;
@@ -312,7 +312,7 @@ class Data extends AbstractData
                     }
                 } catch (\Exception $e) {
                     $orderId = method_exists($order, 'getEntityId') ? $order->getEntityId() : null;
-                    $this->yotpoOrdersLogger->info(
+                    $this->yotpoOrdersLogger->infoLog(
                         __(
                             'Exception raised within prepareParentData - orderId: %1, Exception Message: %2',
                             $orderId,
@@ -340,7 +340,7 @@ class Data extends AbstractData
                     }
                 }
             } catch (\Exception $e) {
-                $this->yotpoOrdersLogger->info(' prepareParentData() :  ' . $e->getMessage(), []);
+                $this->yotpoOrdersLogger->infoLog(' prepareParentData() :  ' . $e->getMessage(), []);
             }
         }
     }
@@ -473,10 +473,10 @@ class Data extends AbstractData
                 }
             }
         } catch (NoSuchEntityException $e) {
-            $this->yotpoOrdersLogger->info('Orders sync::prepareFulfillments() - NoSuchEntityException: ' .
+            $this->yotpoOrdersLogger->infoLog('Orders sync::prepareFulfillments() - NoSuchEntityException: ' .
                 $e->getMessage(), []);
         } catch (LocalizedException $e) {
-            $this->yotpoOrdersLogger->info('Orders sync::prepareFulfillments() - LocalizedException: ' .
+            $this->yotpoOrdersLogger->infoLog('Orders sync::prepareFulfillments() - LocalizedException: ' .
                 $e->getMessage(), []);
         }
         return $fulfillments;

--- a/Model/Sync/Orders/Main.php
+++ b/Model/Sync/Orders/Main.php
@@ -68,7 +68,7 @@ class Main extends AbstractJobs
                             ->from($table)
                             ->where('order_id IN (?) ', array_keys($magentoOrders))
                             ->where('yotpo_id > (?) ', 0);
-        $orders =   $connection->fetchAssoc($orders, []);
+        $orders =   $connection->fetchAssoc($orders);
         foreach ($orders as $order) {
             $return[$order['order_id']]  =   $order;
         }

--- a/Model/Sync/Orders/Processor.php
+++ b/Model/Sync/Orders/Processor.php
@@ -145,7 +145,7 @@ class Processor extends Main
                 $this->stopEnvironmentEmulation();
                 continue;
             }
-            $this->yotpoOrdersLogger->info('Process orders for store : ' . $storeId, []);
+            $this->yotpoOrdersLogger->infoLog('Process orders for store : ' . $storeId, []);
             $orders = $orderByStore[$storeId] ?? [];
             $this->processOrders($orders);
             $this->stopEnvironmentEmulation();
@@ -168,7 +168,7 @@ class Processor extends Main
             return;
         }
         $this->currentStoreId = $this->config->getStoreId();
-        $this->yotpoOrdersLogger->info(
+        $this->yotpoOrdersLogger->infoLog(
             __(
                 'Process order for Magento Store ID: %1, Name: %2',
                 $storeId,
@@ -207,7 +207,7 @@ class Processor extends Main
         foreach ($orderItems as $order) {
             $storeId = $order->getStoreId();
             if ($this->config->isSyncResetInProgress($storeId, 'order')) {
-                $this->yotpoOrdersLogger->info(
+                $this->yotpoOrdersLogger->infoLog(
                     __(
                         'Order sync is skipped because order sync reset is in progress
                          - Magento Store ID: %1, Name: %2',
@@ -219,7 +219,7 @@ class Processor extends Main
             }
             $productsMissing = $this->checkMissingProducts($order);
             if ($productsMissing) {
-                $this->yotpoOrdersLogger->info('Products not exist for order  : ' . $order->getId(), []);
+                $this->yotpoOrdersLogger->infoLog('Products not exist for order  : ' . $order->getId(), []);
                 $ordersWithMissedProducts[] = $order->getId();
                 $this->updateOrderAttribute([$order->getId()], self::SYNCED_TO_YOTPO_ORDER, 1);
                 continue;
@@ -262,7 +262,7 @@ class Processor extends Main
                             $this->isCommandLineSync
                         )) {
                             $this->updateOrderAttribute([$magentoOrderId], self::SYNCED_TO_YOTPO_ORDER, 1);
-                            $this->yotpoOrdersLogger->info('Order sync cannot be done for orderId: '
+                            $this->yotpoOrdersLogger->infoLog('Order sync cannot be done for orderId: '
                                 . $magentoOrderId . ', due to response code: ' . $responseCode, []);
                             continue;
                         } else {
@@ -287,7 +287,7 @@ class Processor extends Main
                     }
                 } catch (\Exception $e) {
                     $magentoOrderId = method_exists($magentoOrder, 'getEntityId') ? $magentoOrder->getEntityId() : null;
-                    $this->yotpoOrdersLogger->info(
+                    $this->yotpoOrdersLogger->infoLog(
                         __(
                             'Exception raised within processOrders - magentoOrderId: %1, Exception Message: %2',
                             $magentoOrderId,
@@ -322,7 +322,7 @@ class Processor extends Main
         $ordersToUpdate[] = $magentoOrderId;
         $currentTime = date('Y-m-d H:i:s');
         if ($productsMissing) {
-            $this->yotpoOrdersLogger->info('Products not exist for order  : ' . $magentoOrderId, []);
+            $this->yotpoOrdersLogger->infoLog('Products not exist for order  : ' . $magentoOrderId, []);
             $yotpoTableFinalData[] = $this->prepareYotpoTableDataForMissingProducts($magentoOrderId, $currentTime);
             $this->insertOrUpdateYotpoTableData($yotpoTableFinalData);
             $this->updateOrderAttribute($ordersToUpdate, self::SYNCED_TO_YOTPO_ORDER, 1);
@@ -332,7 +332,7 @@ class Processor extends Main
         }
         $mappedOrderStatuses = $this->data->getMappedOrderStatuses();
         if (!isset($mappedOrderStatuses[$magentoOrder->getStatus()])) {
-            $this->yotpoOrdersLogger->info(
+            $this->yotpoOrdersLogger->infoLog(
                 'Missing order status mapping for Order# ' . $magentoOrderId.' - Status : '. $magentoOrder->getStatus(),
                 []
             );
@@ -349,7 +349,7 @@ class Processor extends Main
         }
 
         try {
-            $this->yotpoOrdersLogger->info('Order attribute updated to 0 for order : ' . $magentoOrderId, []);
+            $this->yotpoOrdersLogger->infoLog('Order attribute updated to 0 for order : ' . $magentoOrderId, []);
             if (!$this->config->isRealTimeOrdersSyncActive()) {
                 return;
             }
@@ -361,7 +361,7 @@ class Processor extends Main
                     $responseCode = $yotpoSyncedOrders[$magentoOrderId]['response_code'];
                     if (!$this->config->canResync($responseCode, $yotpoSyncedOrders[$magentoOrderId]['yotpo_id'])) {
                         $this->updateOrderAttribute($magentoOrderId, self::SYNCED_TO_YOTPO_ORDER, 1);
-                        $this->yotpoOrdersLogger->info('Order sync cannot be done for orderId: '
+                        $this->yotpoOrdersLogger->infoLog('Order sync cannot be done for orderId: '
                             . $magentoOrderId . ', due to response code: ' . $responseCode, []);
                         return;
                     } else {
@@ -382,7 +382,7 @@ class Processor extends Main
                     $yotpoSyncedOrders,
                     $magentoOrder->getId()
                 ) : false;
-            $this->yotpoOrdersLogger->info('Last sync date updated for order : '
+            $this->yotpoOrdersLogger->infoLog('Last sync date updated for order : '
                 . $magentoOrderId, []);
             if ($yotpoTableData) {
                 if (!$yotpoTableData['yotpo_id'] && array_key_exists($magentoOrderId, $yotpoSyncedOrders)) {
@@ -394,7 +394,7 @@ class Processor extends Main
                 if ($this->config->canUpdateCustomAttribute($yotpoTableData['response_code'])) {
                     $this->updateOrderAttribute($magentoOrderId, self::SYNCED_TO_YOTPO_ORDER, 1);
                 }
-                $this->yotpoOrdersLogger->info('Order attribute updated to 1 for order : '
+                $this->yotpoOrdersLogger->infoLog('Order attribute updated to 1 for order : '
                     . $magentoOrderId, []);
             }
             $this->updateLastSyncDate($currentTime);
@@ -454,7 +454,7 @@ class Processor extends Main
         $incrementId = $order->getIncrementId();
         $orderId = $order->getEntityId();
         $dataType = $isYotpoSyncedOrder ? 'update' : 'create';
-        $this->yotpoOrdersLogger->info(
+        $this->yotpoOrdersLogger->infoLog(
             __(
                 'Orders sync, starting sync - Order ID: %1, Increment ID: %2',
                 $orderId,
@@ -463,17 +463,17 @@ class Processor extends Main
         );
         $orderData = $this->data->prepareData($order, $dataType, $yotpoSyncedOrders);
         if (!$orderData) {
-            $this->yotpoOrdersLogger->info('Orders sync - no new data to sync', []);
+            $this->yotpoOrdersLogger->infoLog('Orders sync - no new data to sync', []);
             return [];
         }
-        $this->yotpoOrdersLogger->info('Orders sync - data prepared - Order ID - ' . $orderId, []);
+        $this->yotpoOrdersLogger->infoLog('Orders sync - data prepared - Order ID - ' . $orderId, []);
         $productIds = $this->data->getLineItemsIds();
         $storeId = $order->getStoreId();
         if ($productIds) {
             $visibleItems = $order->getAllVisibleItems();
             $isProductSyncSuccess = $this->catalogProcessor->syncProducts($productIds, $visibleItems, $storeId);
             if (!$isProductSyncSuccess) {
-                $this->yotpoOrdersLogger->info('Products sync failed - Order ID - ' . $order->getId(), []);
+                $this->yotpoOrdersLogger->infoLog('Products sync failed - Order ID - ' . $order->getId(), []);
                 return [];
             }
         }
@@ -506,7 +506,7 @@ class Processor extends Main
                 $response->setData('yotpo_id', $yotpoOrderId);
             }
 
-            $this->yotpoOrdersLogger->info('Orders sync - success - ' . $orderId, []);
+            $this->yotpoOrdersLogger->infoLog('Orders sync - success - ' . $orderId, []);
         } elseif ($response->getData('status') == 409) {//order already exists in Yotpo and not in custom table
             $response = $this->yotpoCoreSync->sync(
                 'GET',

--- a/Services/CatalogCategoryProductService.php
+++ b/Services/CatalogCategoryProductService.php
@@ -53,7 +53,7 @@ class CatalogCategoryProductService extends AbstractJobs
             $productId
         );
 
-        $productCategoriesIdsMap = $connection->fetchAssoc($categoryProductsQuery, 'category_id');
+        $productCategoriesIdsMap = $connection->fetchAssoc($categoryProductsQuery);
         return array_keys($productCategoriesIdsMap);
     }
 
@@ -72,7 +72,7 @@ class CatalogCategoryProductService extends AbstractJobs
             $categoryId
         );
 
-        $currentProductsInCategory = $connection->fetchAssoc($select, 'product_id');
+        $currentProductsInCategory = $connection->fetchAssoc($select);
         return array_keys($currentProductsInCategory);
     }
 }

--- a/Setup/Patch/Data/UpdateConfigData.php
+++ b/Setup/Patch/Data/UpdateConfigData.php
@@ -76,7 +76,7 @@ class UpdateConfigData implements DataPatchInterface
         )->where(
             $connection->quoteInto('coreConfigData.path = ?', self::XML_PATH_CUSTOM_ORDER_STATUS)
         );
-        $items = $connection->fetchAssoc($select, []);
+        $items = $connection->fetchAssoc($select);
         if ($items) {
             foreach ($items as $item) {
                 $newData[] = $this->prepareNewData($item['scope'], $item['scope_id'], $item['value']);

--- a/Setup/Patch/Data/UpdateOrdersSyncDate.php
+++ b/Setup/Patch/Data/UpdateOrdersSyncDate.php
@@ -55,7 +55,7 @@ class UpdateOrdersSyncDate implements DataPatchInterface
         )->where(
             $connection->quoteInto('coreConfigData.path = ?', self::XML_PATH_ORDERS_SYNC_START_DATE)
         );
-        $items = $connection->fetchAssoc($select, []);
+        $items = $connection->fetchAssoc($select);
         if ($items) {
             foreach ($items as $item) {
                 $newData[] = $this->prepareNewData($item['scope'], $item['scope_id'], $item['value']);

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
     "name": "yotpo/module-yotpo-core",
     "description": "Yotpo Reviews core extension for Magento2",
-    "version": "4.0.26",
+    "version": "4.0.27",
     "license": [
         "OSL-3.0",
         "AFL-3.0"
     ],
     "require": {
-        "php": "~5.6.0|^7.0",
+        "php": "~5.6.0|^7.0|^8.0",
         "magento/framework": ">=102.0.0"
     },
     "replace": {

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_Core" setup_version="4.0.26" />
+    <module name="Yotpo_Core" setup_version="4.0.27" />
 </config>


### PR DESCRIPTION
Adding M2.4.4 support to the new extension.
Together with:
- https://github.com/YotpoLtd/magento2-module-messaging/pull/112
- https://github.com/YotpoLtd/magento2-module-reviews/pull/75
- https://github.com/YotpoLtd/magento2-module-combined/pull/70

## Developer Notes
1. Magento is using Monolog as the logging interface.\
In M2.4.4, Magento upgraded to Monolog v2 (previously it was v1).\
`Model\Logger\Main` is extending `Monolog\Logger`, but in v2, the signature of the overriden methods changed (`info` and `error`), which caused the class to break.\
I've changed the naming of the methods so they wouldn't override the parent methods.
2. One of the underlying modules changed the interface of `fetchAssoc`.\
In M2.4.4, the usage of fetchAssoc with `fetchAssoc($sql, 'someColumnName')` is throwing exceptions from the MySQL.\
According to Zend documentatoin, `fetchAssoc` takes the first column as the key of the returned hash, so I've checked in each usage that the first column represents the column that we wanted to have as the key, and deleted the `someColumnName` as the second arhument of the invokation.