### PR TITLE
Fixed Magento CLI installation issues (Connection "default" is not defined).

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,4 +1,10 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_Core" setup_version="4.0.31" />
+    <module name="Yotpo_Core" setup_version="4.0.31">
+        <sequence>
+            <module name="Magento_Catalog"/>
+            <module name="Magento_Sales"/>
+            <module name="Magento_Customer"/>
+        </sequence>
+    </module>
 </config>


### PR DESCRIPTION
* Fixed Magento CLI installation issues by lazyloading Yotpo CLI dependencies.
*This should prevent `Connection "default" is not defined` error on marketplace automated tests.