### PR TITLE
COR-81 handle config product price

### DIFF
--- a/Model/Sync/Catalog/Data.php
+++ b/Model/Sync/Catalog/Data.php
@@ -6,7 +6,6 @@ use Magento\CatalogInventory\Model\StockRegistry;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Yotpo\Core\Model\Config as YotpoCoreConfig;
-use Magento\Framework\UrlInterface;
 use Magento\Catalog\Model\Product;
 use Magento\ConfigurableProduct\Model\ResourceModel\Product\Type\Configurable;
 use Magento\Catalog\Model\ProductRepository;
@@ -51,109 +50,9 @@ class Data extends Main
     protected $collectionFactory;
 
     /**
-     * @var array<string, array>
+     * @var MagentoProductToYotpoProductAdapter
      */
-    protected $mappingAttributes = [
-        'row_id' => [
-            'default' => 1,
-            'attr_code' => 'row_id'
-        ],
-        'external_id' => [
-            'default' => 1,
-            'attr_code' => 'entity_id'
-        ],
-        'name' => [
-            'default' => 1,
-            'attr_code' => 'name'
-        ],
-        'description' => [
-            'default' => 0,
-            'attr_code' => '',
-            'method' => 'getProductDescription'
-        ],
-        'url' => [
-            'default' => 1,
-            'attr_code' => 'request_path',
-            'type' => 'url'
-        ],
-        'image_url' => [
-            'default' => 1,
-            'attr_code' => 'image',
-            'type' => 'image'
-        ],
-        'price' => [
-            'default' => 0,
-            'attr_code' => '',
-            'method' => 'getProductPrice'
-        ],
-        'currency' => [
-            'default' => 0,
-            'attr_code' => '',
-            'method' => 'getCurrentCurrency'
-        ],
-        'inventory_quantity' => [
-            'default' => 0,
-            'attr_code' => '',
-            'method' => 'getProductQty'
-        ],
-        'is_discontinued' => [
-            'default' => 0,
-            'attr_code' => '',
-            'method' => ''
-        ],
-        'group_name' => [
-            'default' => 0,
-            'attr_code' => 'attr_product_group',
-            'method' => 'getDataFromConfig'
-        ],
-        'brand' => [
-            'default' => 0,
-            'attr_code' => 'attr_brand',
-            'method' => 'getDataFromConfig'
-        ],
-        'sku' => [
-            'default' => 1,
-            'attr_code' => 'sku'
-        ],
-        'mpn' => [
-            'default' => 0,
-            'attr_code' => 'attr_mpn',
-            'method' => 'getDataFromConfig'
-        ],
-        'handle' => [
-            'default' => 1,
-            'attr_code' => 'sku'
-        ],
-        'gtins' => [
-            'EAN' => [
-                'default' => 0,
-                'attr_code' => 'attr_ean',
-                'method' => 'getDataFromConfig'
-            ],
-            'UPC' => [
-                'default' => 0,
-                'attr_code' => 'attr_upc',
-                'method' => 'getDataFromConfig'
-            ],
-            'ISBN' => [
-                'default' => 0,
-                'attr_code' => 'attr_isbn',
-                'method' => 'getDataFromConfig'
-            ]
-        ],
-        'custom_properties' => [
-            'is_blocklisted' => [
-                'default' => 0,
-                'attr_code' => 'attr_blocklist',
-                'method' => 'getDataFromConfig'
-            ],
-            'review_form_tag' => [
-                'default' => 0,
-                'attr_code' => 'attr_crf',
-                'method' => 'getDataFromConfig'
-            ]
-        ]
-    ];
+    protected $magentoProductToYotpoProductAdapter;
 
     /**
      * @var StockRegistry
@@ -175,6 +74,7 @@ class Data extends Main
      * @param CollectionFactory $collectionFactory
      * @param StockRegistry $stockRegistry
      * @param YotpoCoreCatalogLogger $yotpoCatalogLogger
+     * @param MagentoProductToYotpoProductAdapter $magentoProductToYotpoProductAdapter
      */
     public function __construct(
         YotpoCoreConfig $yotpoCoreConfig,
@@ -184,7 +84,8 @@ class Data extends Main
         ResourceConnection $resourceConnection,
         CollectionFactory $collectionFactory,
         StockRegistry $stockRegistry,
-        YotpoCoreCatalogLogger $yotpoCatalogLogger
+        YotpoCoreCatalogLogger $yotpoCatalogLogger,
+        MagentoProductToYotpoProductAdapter $magentoProductToYotpoProductAdapter
     ) {
         $this->yotpoCoreConfig = $yotpoCoreConfig;
         $this->yotpoResource = $yotpoResource;
@@ -194,6 +95,7 @@ class Data extends Main
         $this->stockRegistry = $stockRegistry;
         $this->mappingAttributes['row_id']['attr_code'] = $this->yotpoCoreConfig->getEavRowIdFieldName();
         $this->logger = $yotpoCatalogLogger;
+        $this->magentoProductToYotpoProductAdapter = $magentoProductToYotpoProductAdapter;
         parent::__construct($resourceConnection);
     }
 
@@ -214,7 +116,7 @@ class Data extends Main
             $entityId = $item->getData('entity_id');
             $productsId[] = $entityId;
             $productsObject[$entityId] = $item;
-            $syncItems[$entityId] = $this->attributeMapping($item);
+            $syncItems[$entityId] = $this->adaptMagentoProductToYotpoProduct($item);
         }
         $visibleVariantsData = [];
         $productIdsToParentIdsMap = [];
@@ -360,188 +262,8 @@ class Data extends Main
         return $syncItems;
     }
 
-    /**
-     * Mapping the yotpo data with magento data - product sync
-     *
-     * @param Product $item
-     * @return array<string, string|array>
-     * @throws NoSuchEntityException
-     */
-    public function attributeMapping(Product $item)
-    {
-        $itemArray = [];
-        $mapAttributes = $this->mappingAttributes;
-
-        foreach ($mapAttributes as $key => $attr) {
-            try {
-                if ($key === 'gtins') {
-                    $value = $this->prepareGtinsData($attr, $item);
-                } elseif ($key === 'custom_properties') {
-                    $value = $this->prepareCustomProperties($attr, $item);
-                } elseif ($key === 'is_discontinued') {
-                    $value = false;
-                } else {
-                    if ($attr['default']) {
-                        $data = $item->getData($attr['attr_code']);
-
-                        if (isset($attr['type']) && $attr['type'] === 'url') {
-                            $data = $item->getProductUrl();
-                        }
-
-                        if (isset($attr['type']) && $attr['type'] === 'image') {
-                            $baseUrl = $this->yotpoCoreConfig->getBaseUrl(UrlInterface::URL_TYPE_MEDIA);
-                            $data = $data ? $baseUrl . 'catalog/product' . $data : null;
-                        }
-                        $value = $data;
-                    } elseif (isset($attr['method']) && $attr['method']) {
-
-                        $configKey = isset($attr['attr_code']) && $attr['attr_code'] ?
-                            $attr['attr_code'] : '';
-
-                        $method = $attr['method'];
-                        $itemValue = $this->$method($item, $configKey);
-                        $value = $itemValue ?: ($method == 'getProductPrice' ? 0.00 : $itemValue);
-                    } else {
-                        $value = '';
-                    }
-                    if ($key == 'group_name' && $value) {
-                        $value = strtolower($value);
-                        $value = str_replace(' ', '_', $value);
-                        $value = preg_replace('/[^A-Za-z0-9_-]/', '-', $value);
-                        $value = substr((string)$value, 0, 100);
-                    }
-                }
-                $itemArray[$key] = $value;
-                if (($key == 'custom_properties' || $key == 'gtins') && !$value) {
-                    unset($itemArray[$key]);
-                }
-            } catch (\Exception $e) {
-                $this->logger->infoLog(
-                    __(
-                        'Exception raised within attributeMapping - $key: %1, $attr: %2 Exception Message: %3',
-                        $key,
-                        $attr,
-                        $e->getMessage()
-                    )
-                );
-            }
-        }
-
-        return $itemArray;
-    }
-
-    /**
-     * Get Current Currency
-     *
-     * @return string
-     * @throws NoSuchEntityException
-     */
-    public function getCurrentCurrency()
-    {
-        return $this->yotpoCoreConfig->getCurrentCurrency();
-    }
-
-    /**
-     * Get product quantity
-     * @param Product $item
-     * @return float
-     * @throws NoSuchEntityException
-     */
-    public function getProductQty($item)
-    {
-        return $this->stockRegistry->getStockItem($item->getId(), $this->yotpoCoreConfig->getWebsiteId())->getQty();
-    }
-
-    /**
-     * Get value from config table - dynamically
-     * @param Product $item
-     * @param string $configKey
-     * @return mixed|string|null
-     * @throws LocalizedException
-     * @throws NoSuchEntityException
-     */
-    public function getDataFromConfig($item, $configKey = '')
-    {
-        $configValue = $this->yotpoCoreConfig->getConfig($configKey) ?: '';
-        if ($configValue) {
-            $value = $item->getAttributeText($configValue) ?: '';
-            if (!$value) {
-                $value = $item->getData($configValue) ?: '';
-            }
-        } else {
-            return null;
-        }
-        return $value ?: '';
-    }
-
-    /**
-     * Get GTINs data from config table
-     *
-     * @param array<int, array> $array
-     * @param Product $item
-     * @return array<int, array>
-     */
-    protected function prepareGtinsData($array, $item)
-    {
-        $resultArray = [];
-        foreach ($array as $key => $value) {
-            $configKey = isset($value['attr_code']) && $value['attr_code'] ?
-                $value['attr_code'] : '';
-            $method = $value['method'];
-            $value = $this->$method($item, $configKey);
-
-            if ($value && $value !== 'NULL') {
-                $resultArray[] = [
-                    'declared_type' => $key,
-                    'value' => $value
-                ];
-            }
-        }
-        return $resultArray;
-    }
-
-    /**
-     * Prepare custom attributes for product sync
-     *
-     * @param array<string, array> $array
-     * @param Product $item
-     * @return array<string, array>
-     */
-    protected function prepareCustomProperties($array, $item)
-    {
-        $resultArray = [];
-        foreach ($array as $key => $value) {
-            $configKey = isset($value['attr_code']) && $value['attr_code'] ?
-                $value['attr_code'] : '';
-
-            $method = $value['method'];
-            $itemValue = $this->$method($item, $configKey);
-            if ($key === 'is_blocklisted' || $key === 'review_form_tag') {
-                $configValue = $this->yotpoCoreConfig->getConfig($configKey) ?: '';
-                if ($configValue) {
-                    if ($key === 'is_blocklisted') {
-                        $resultArray[$key] = $itemValue === 1 || $itemValue == 'Yes' || $itemValue === true;
-                    } elseif ($key === 'review_form_tag') {
-                        $itemValue = str_replace(',', '_', $itemValue);
-                        $itemValue = substr($itemValue, 0, 255);
-                        $resultArray[$key] = $itemValue ?: '';
-                    }
-                }
-            } else {
-                $resultArray[$key] = $itemValue;
-            }
-        }
-        return $resultArray;
-    }
-
-    /**
-     * Get product price
-     * @param Product $item
-     * @return float
-     */
-    public function getProductPrice($item)
-    {
-        return $item->getPrice() ?: 0.00;
+    public function adaptMagentoProductToYotpoProduct(Product $item) {
+        return $this->magentoProductToYotpoProductAdapter->adapt($item);
     }
 
     /**
@@ -559,17 +281,6 @@ class Data extends Main
         }
 
         return $result;
-    }
-
-    /**
-     * Get product description
-     * @param Product $item
-     * @return string
-     */
-    public function getProductDescription(Product $item)
-    {
-        return trim($item->getData('description')) ?:
-            trim($item->getData('short_description'));
     }
 
     /**

--- a/Model/Sync/Catalog/MagentoProductToYotpoProductAdapter.php
+++ b/Model/Sync/Catalog/MagentoProductToYotpoProductAdapter.php
@@ -5,6 +5,7 @@ namespace Yotpo\Core\Model\Sync\Catalog;
 use Magento\Framework\UrlInterface;
 use Magento\Catalog\Model\Product;
 use Magento\CatalogInventory\Model\StockRegistry;
+use Magento\Catalog\Model\ProductRepository;
 use Yotpo\Core\Model\Config as YotpoCoreConfig;
 
 /**
@@ -24,10 +25,17 @@ class MagentoProductToYotpoProductAdapter
         'review_form_tag' => 'getReviewFormTag'
     ];
 
+    const CONFIGURABLE_PRODUCT_CODE = \Magento\ConfigurableProduct\Model\Product\Type\Configurable::TYPE_CODE;
+
     /**
      * @var StockRegistry
      */
     protected $stockRegistry;
+
+    /**
+     * @var ProductRepository
+     */
+    protected $productRepository;
 
     /**
      * @var YotpoCoreConfig
@@ -36,13 +44,16 @@ class MagentoProductToYotpoProductAdapter
 
     /**
      * @param StockRegistry $stockRegistry
+     * @param ProductRepository $productRepository
      * @param YotpoCoreConfig $yotpoCoreConfig
      */
     public function __construct(
         StockRegistry $stockRegistry,
+        ProductRepository $productRepository,
         YotpoCoreConfig $yotpoCoreConfig
     ) {
         $this->stockRegistry = $stockRegistry;
+        $this->productRepository = $productRepository;
         $this->yotpoCoreConfig = $yotpoCoreConfig;
     }
 
@@ -148,8 +159,17 @@ class MagentoProductToYotpoProductAdapter
      * @return float
      */
     private function getPrice(Product $item) {
-        $productPrice = $item->getPrice() ?: 0.00;
-        return $productPrice ?: 0.00;
+        if ($item->getTypeId() == self::CONFIGURABLE_PRODUCT_CODE) {
+            $itemVariantIdsObject = $item->getTypeInstance()->getChildrenIds($item->getId());
+            if (isset($itemVariantIdsObject[0]) && count($itemVariantIdsObject[0]) > 0) {
+                $itemVariantIds = $itemVariantIdsObject[0];
+                $firstVariantId = reset($itemVariantIds);
+                $variant = $this->productRepository->getById($firstVariantId);
+                return $variant->getPrice() ?: 0.00;
+            }
+        }
+
+        return $item->getPrice() ?: 0.00;
     }
 
     /**

--- a/Model/Sync/Catalog/MagentoProductToYotpoProductAdapter.php
+++ b/Model/Sync/Catalog/MagentoProductToYotpoProductAdapter.php
@@ -1,0 +1,329 @@
+<?php
+
+namespace Yotpo\Core\Model\Sync\Catalog;
+
+use Magento\Framework\UrlInterface;
+use Magento\Catalog\Model\Product;
+use Magento\CatalogInventory\Model\StockRegistry;
+use Yotpo\Core\Model\Config as YotpoCoreConfig;
+
+/**
+ * Class Logger - For customized logging
+ */
+class MagentoProductToYotpoProductAdapter
+{
+
+    const GTIN_TYPE_TO_GETTER_METHOD_NAME_MAP = [
+        'EAN' => 'getEan',
+        'UPC' => 'getUpc',
+        'ISBN' => 'getIsbn'
+    ];
+
+    const CUSTOM_ATTRIBUTE_TO_GETTER_METHOD_NAME_MAP = [
+        'is_blocklisted' => 'getIsBlocklisted',
+        'review_form_tag' => 'getReviewFormTag'
+    ];
+
+    /**
+     * @var StockRegistry
+     */
+    protected $stockRegistry;
+
+    /**
+     * @var YotpoCoreConfig
+     */
+    protected $yotpoCoreConfig;
+
+    /**
+     * @param StockRegistry $stockRegistry
+     * @param YotpoCoreConfig $yotpoCoreConfig
+     */
+    public function __construct(
+        StockRegistry $stockRegistry,
+        YotpoCoreConfig $yotpoCoreConfig
+    ) {
+        $this->stockRegistry = $stockRegistry;
+        $this->yotpoCoreConfig = $yotpoCoreConfig;
+    }
+
+    /**
+     * @param Product $item
+     * @return array
+     */
+    public function adapt(Product $item) {
+        $yotpoProduct = [];
+
+        $yotpoProduct['row_id'] = $this->getRowId($item);
+        $yotpoProduct['external_id'] = $this->getExternalId($item);
+        $yotpoProduct['name'] = $this->getName($item);
+        $yotpoProduct['description'] = $this->getDescription($item);
+        $yotpoProduct['url'] = $this->getUrl($item);
+        $yotpoProduct['image_url'] = $this->getImageUrl($item);
+        $yotpoProduct['price'] = $this->getPrice($item);
+        $yotpoProduct['currency'] = $this->getCurrency($item);
+        $yotpoProduct['inventory_quantity'] = $this->getInventoryQuantity($item);
+        $yotpoProduct['is_discontinued'] = false;
+        $yotpoProduct['group_name'] = $this->getGroupName($item);
+        $yotpoProduct['brand'] = $this->getBrand($item);
+        $yotpoProduct['sku'] = $this->getSku($item);
+        $yotpoProduct['mpn'] = $this->getMpn($item);
+        $yotpoProduct['handle'] = $this->getHandle($item);
+
+        $gtins = $this->getGtins($item);
+        if ($gtins) {
+            $yotpoProduct['gtins'] = $gtins;
+        }
+
+        $customProperties = $this->getCustomProperties($item);
+        if ($customProperties) {
+            $yotpoProduct['custom_properties'] = $customProperties;
+        }
+
+        return $yotpoProduct;
+    }
+
+    /**
+     * @param Product $item
+     * @return mixed
+     */
+    private function getRowId(Product $item) {
+        $rowIdFieldName = $this->yotpoCoreConfig->getEavRowIdFieldName();
+        return $item->getData($rowIdFieldName);
+    }
+
+    /**
+     * @param Product $item
+     * @return mixed
+     */
+    private function getExternalId(Product $item) {
+        return $item->getData('entity_id');
+    }
+
+    /**
+     * @param Product $item
+     * @return mixed
+     */
+    private function getName(Product $item) {
+        return $item->getData('name');
+    }
+
+    /**
+     * @param Product $item
+     * @return string
+     */
+    private function getDescription(Product $item) {
+        $description = $item->getData('description');
+        if ($description) {
+            return trim($description);
+        }
+
+        $shortDescription = $item->getData('short_description');
+        if ($shortDescription) {
+            return trim($shortDescription);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param Product $item
+     * @return mixed
+     */
+    private function getUrl(Product $item) {
+        return $item->getProductUrl();
+    }
+
+    /**
+     * @param Product $item
+     * @return string|null
+     */
+    private function getImageUrl(Product $item) {
+        $image = $item->getData('image');
+        $baseUrl = $this->yotpoCoreConfig->getBaseUrl(UrlInterface::URL_TYPE_MEDIA);
+        return $image ? $baseUrl . 'catalog/product' . $image : null;
+    }
+
+    /**
+     * @param Product $item
+     * @return float
+     */
+    private function getPrice(Product $item) {
+        $productPrice = $item->getPrice() ?: 0.00;
+        return $productPrice ?: 0.00;
+    }
+
+    /**
+     * @param Product $item
+     * @return string
+     */
+    private function getCurrency(Product $item) {
+        return $this->yotpoCoreConfig->getCurrentCurrency();
+    }
+
+    /**
+     * @param Product $item
+     * @return mixed
+     */
+    private function getInventoryQuantity(Product $item) {
+        return $this->stockRegistry->getStockItem($item->getId(), $this->yotpoCoreConfig->getWebsiteId())->getQty();
+    }
+
+    /**
+     * @param Product $item
+     * @return false|mixed|string|null
+     */
+    private function getGroupName(Product $item) {
+        $groupName = $this->getAttributeValueForItemByConfigKey($item, 'attr_product_group');
+        if ($groupName) {
+            $groupName = strtolower($groupName);
+            $groupName = str_replace(' ', '_', $groupName);
+            $groupName = preg_replace('/[^A-Za-z0-9_-]/', '-', $groupName);
+            $groupName = substr((string) $groupName, 0, 100);
+        }
+
+        return $groupName;
+    }
+
+    /**
+     * @param Product $item
+     * @return mixed|string|null
+     */
+    private function getBrand(Product $item) {
+        return $this->getAttributeValueForItemByConfigKey($item, 'attr_brand');
+    }
+
+    /**
+     * @param Product $item
+     * @return mixed
+     */
+    private function getSku(Product $item) {
+        return $item->getData('sku');
+    }
+
+    /**
+     * @param Product $item
+     * @return mixed|string|null
+     */
+    private function getMpn(Product $item) {
+        return $this->getAttributeValueForItemByConfigKey($item, 'attr_mpn');
+    }
+
+    /**
+     * @param Product $item
+     * @return mixed
+     */
+    private function getHandle(Product $item) {
+        return $item->getData('sku');
+    }
+
+    /**
+     * @param Product $item
+     * @return array
+     */
+    private function getGtins(Product $item) {
+        $gtins = [];
+
+        foreach (self::GTIN_TYPE_TO_GETTER_METHOD_NAME_MAP as $gtinType => $getterMethodName) {
+            $gtinValue = $this->$getterMethodName($item);
+            if ($gtinValue && $gtinValue !== 'NULL') {
+                $gtins[] = [
+                    'declared_type' => $gtinType,
+                    'value' => $gtinValue
+                ];
+            }
+        }
+
+        return $gtins;
+    }
+
+    /**
+     * @param Product $item
+     * @return mixed|string|null
+     */
+    private function getEan(Product $item) {
+        return $this->getAttributeValueForItemByConfigKey($item, 'attr_ean');
+    }
+
+    /**
+     * @param Product $item
+     * @return mixed|string|null
+     */
+    private function getUpc(Product $item) {
+        return $this->getAttributeValueForItemByConfigKey($item, 'attr_upc');
+    }
+
+    /**
+     * @param Product $item
+     * @return mixed|string|null
+     */
+    private function getIsbn(Product $item) {
+        return $this->getAttributeValueForItemByConfigKey($item, 'attr_isbn');
+    }
+
+    /**
+     * @param Product $item
+     * @return array
+     */
+    private function getCustomProperties(Product $item) {
+        $customProperties = [];
+
+        foreach (self::CUSTOM_ATTRIBUTE_TO_GETTER_METHOD_NAME_MAP as $customPropertyType => $getterMethodName) {
+            $customPropertyValue = $this->$getterMethodName($item);
+            if ($customPropertyValue && $customPropertyValue !== 'NULL') {
+                $customProperties[$customPropertyType] = $customPropertyValue;
+            }
+        }
+
+        return $customProperties;
+    }
+
+    /**
+     * @param Product $item
+     * @return bool
+     */
+    private function getIsBlocklisted(Product $item) {
+        $isBlocklisted = $this->getAttributeValueForItemByConfigKey($item, 'attr_blocklist');
+        return $isBlocklisted === 1 || $isBlocklisted == 'Yes' || $isBlocklisted === true;
+    }
+
+    /**
+     * @param Product $item
+     * @return false|string
+     */
+    private function getReviewFormTag(Product $item) {
+        $reviewFormTag = $this->getAttributeValueForItemByConfigKey($item, 'attr_crf');
+        if ($reviewFormTag === null) {
+            return '';
+        }
+
+        $reviewFormTag = str_replace(',', '_', $reviewFormTag);
+        $reviewFormTag = substr($reviewFormTag, 0, 255);
+        return $reviewFormTag ?: '';
+    }
+
+    /**
+     * @param Product $item
+     * @param string $configKey
+     * @return mixed|string|null
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    private function getAttributeValueForItemByConfigKey($item, $configKey)
+    {
+        $attributeKey = $this->getAttributeKeyByConfigKey($configKey);
+        if ($attributeKey) {
+            $attributeValue = $item->getAttributeText($attributeKey) ?: $item->getData($attributeKey);
+        } else {
+            return null;
+        }
+        return $attributeValue ?: '';
+    }
+
+    /**
+     * @param string $configKey
+     * @return string
+     */
+    private function getAttributeKeyByConfigKey($configKey) {
+        return $this->yotpoCoreConfig->getConfig($configKey) ?: '';
+    }
+}

--- a/Model/Sync/Catalog/Processor.php
+++ b/Model/Sync/Catalog/Processor.php
@@ -978,7 +978,7 @@ class Processor extends Main
             false
         );
         /** @phpstan-ignore-next-line */
-        $productData = $this->catalogData->attributeMapping(reset($parentProductData));
+        $productData = $this->catalogData->adaptMagentoProductToYotpoProduct(reset($parentProductData));
         if (isset($productData['row_id'])) {
             unset($productData['row_id']);
         }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-core",
     "description": "Yotpo Reviews core extension for Magento2",
-    "version": "4.0.31",
+    "version": "4.0.32",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_Core" setup_version="4.0.31">
+    <module name="Yotpo_Core" setup_version="4.0.32">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
## Introduction
In order to support Reviews' 'Most expensive' sorting feature for ARRs, we needed to sync a price for configurable products.
The logic that was implemented is that the price of the configurable product will be represented by the price of the first simple product returned.

In addition to that, I've refactored the logic behind adapting the product to the Yotpo structure and resolved compatibility issues with PHP 8.1.

Part of https://github.com/YotpoLtd/magento2-module-core/pull/216.