### PR TITLE
YOTP-438 fix(MagentoProductToYotpoProductAdapter):fixed blocklisted and review form null handling

### DIFF
--- a/Model/Sync/Catalog/MagentoProductToYotpoProductAdapter.php
+++ b/Model/Sync/Catalog/MagentoProductToYotpoProductAdapter.php
@@ -255,9 +255,11 @@ class MagentoProductToYotpoProductAdapter
 
         foreach (self::CUSTOM_ATTRIBUTE_TO_GETTER_METHOD_NAME_MAP as $customPropertyType => $getterMethodName) {
             $customPropertyValue = $this->$getterMethodName($item);
-            if ($customPropertyValue && $customPropertyValue !== 'NULL') {
-                $customProperties[$customPropertyType] = $customPropertyValue;
+            if ($customPropertyValue === null || $customPropertyValue === 'NULL') {
+                continue;
             }
+
+            $customProperties[$customPropertyType] = $customPropertyValue;
         }
 
         return $customProperties;
@@ -278,9 +280,9 @@ class MagentoProductToYotpoProductAdapter
      */
     private function getReviewFormTag(Product $item) {
         $reviewFormTag = $this->getAttributeValueForItemByConfigKey($item, self::CRF_CONFIG_KEY);
-        if ($reviewFormTag === null) {
-            return '';
-        }
+        if ($reviewFormTag === null || $reviewFormTag === '') {
+            return $reviewFormTag;
+        };
 
         $reviewFormTag = str_replace(',', '_', $reviewFormTag);
         $reviewFormTag = substr($reviewFormTag, 0, 255);


### PR DESCRIPTION
In Magento, custom properties such as `is_blocklisted` or `review_form_tag` are configured with custom attributes.
As part of the V3 API, we're not changing values of properties when the given value is `null` (explicit or implicit).

- Whenever a custom attribute is not configured in Magento to represent the value of a custom property, we're sending null value.
- Whenever the the value of the custom attribute was PHP equivalent to FALSE (empty string, null, etc.), we wouldn't include the value of the custom property in the request to the Yotpo API, so we would never update the product with FALSE or empty string values, which are legit, respectively.

This created a scenario where a customer can't un-blocklist or un-group their product from Magento.