### PR TITLE
OCT-FIX fix(SalesOrderPaymentSaveAfter):fixed reset sms consent value after order save

### DIFF
--- a/Observer/Order/SalesOrderPaymentSaveAfter.php
+++ b/Observer/Order/SalesOrderPaymentSaveAfter.php
@@ -65,7 +65,6 @@ class SalesOrderPaymentSaveAfter extends OrderMain implements ObserverInterface
                 'yotpo_accepts_sms_marketing',
                 $acceptsSmsMarketing ?: 0
             );
-            $this->checkoutSession->setYotpoSmsMarketing(0);
         }
         if ($order->getEntityId()) {
             $this->processOrderSync($order);


### PR DESCRIPTION
The sms consent value was reset to 0 after the order payment was saved.
Because a creation of new order also triggers a checkout event, this causes us to send a checkout event with `false` sms consent value, even if the customer approved.