### PR TITLE
OCT-693 fix(Category\Processor\Main):fixed Zend_Http usage for 2.4.6 compatibility

### DIFF
--- a/Model/Sync/Category/Processor/Main.php
+++ b/Model/Sync/Category/Processor/Main.php
@@ -184,7 +184,7 @@ class Main extends AbstractJobs
         $collectionData = $this->data->prepareData($category);
         $collectionData['entityLog'] = 'catalog';
         $url = $this->config->getEndpoint('collections_update', ['{yotpo_collection_id}'], [$yotpoId]);
-        $response = $this->yotpoCoreApiSync->sync(\Zend_Http_Client::PATCH, $url, $collectionData, true);
+        $response = $this->yotpoCoreApiSync->sync(Config::METHOD_PATCH, $url, $collectionData, true);
         $categoryId = $category->getId();
         $storeId = $category->getStoreId();
         if ($this->isImmediateRetry($response, $this->entity, $categoryId, $storeId)) {


### PR DESCRIPTION
Magento stopped supporting Zend HTTP since [version 2.4.6](https://developer-stage.adobe.com/commerce/php/development/backward-incompatible-changes/highlights/#zend_http-replaced-with-laminas-http).
We needed to change the usage of `Zend_Http_Client::PATCH` to the const that exists in the Core Config class.