### PR TITLE
Fix General error: 1525 Incorrect TIMESTAMP value on cron.

### DIFF
--- a/Model/Sync/Orders/Processor.php
+++ b/Model/Sync/Orders/Processor.php
@@ -426,9 +426,12 @@ class Processor extends Main
         $mappedOrderStatuses = $this->data->getMappedOrderStatuses();
 
         $orderCollection = $this->orderFactory->create();
-        $orderCollection
-            ->addFieldToFilter('store_id', ['eq' => $storeId])
-            ->addFieldToFilter('created_at', ['from' => $formattedDate]);
+        $orderCollection->addFieldToFilter('store_id', ['eq' => $storeId]);
+
+        if ($formattedDate) {
+            $orderCollection->addFieldToFilter('created_at', ['from' => $formattedDate]);
+        }
+
         if (!$retryOrderIds) {
             $orderCollection
                 ->addFieldToFilter(self::SYNCED_TO_YOTPO_ORDER, ['eq' => 0])
@@ -436,6 +439,7 @@ class Processor extends Main
         } else {
             $orderCollection->addFieldToFilter('entity_id', ['in' => $retryOrderIds]);
         }
+
         if ($mappedOrderStatuses) {
             $orderCollection->addFieldToFilter('status', ['in' => array_keys($mappedOrderStatuses)]);
         }

--- a/Model/Sync/Orders/Processor.php
+++ b/Model/Sync/Orders/Processor.php
@@ -428,7 +428,7 @@ class Processor extends Main
         $orderCollection = $this->orderFactory->create();
         $orderCollection->addFieldToFilter('store_id', ['eq' => $storeId]);
 
-        if ($formattedDate) {
+        if (null !== $formattedDate) {
             $orderCollection->addFieldToFilter('created_at', ['from' => $formattedDate]);
         }
 


### PR DESCRIPTION
Fix cronjob error:

```
SQLSTATE[HY000]: General error: 1525 Incorrect TIMESTAMP value: '', query was: SELECT `main_table`.* FROM `sales_order` AS `main_table` WHERE (`store_id` = 1) AND (`created_at` >= '') AND (`synced_to_yotpo_order` = 0) AND (`status` IN('pending', 'processing', 'complete', 'closed', 'canceled')) ORDER BY created_at DESC LIMIT 100
```

If `$formattedDate` is null do not add order's collection filter.