### PR TITLE
fix(php):update nullable parameter declarations [ ORB-3609 ]

### DIFF
--- a/Console/Command/ResetYotpoSync.php
+++ b/Console/Command/ResetYotpoSync.php
@@ -59,7 +59,7 @@ class ResetYotpoSync extends Command
     public function __construct(
         ObjectManagerInterface $objectManager,
         AppState $appState,
-        string $name = null
+        $name = null
     ) {
         $this->objectManager = $objectManager;
         $this->appState = $appState;

--- a/Console/Command/RetryYotpoSync.php
+++ b/Console/Command/RetryYotpoSync.php
@@ -72,7 +72,7 @@ class RetryYotpoSync extends Command
     public function __construct(
         ObjectManagerInterface $objectManager,
         AppState $appState,
-        string $name = null
+        $name = null
     ) {
         $this->objectManager = $objectManager;
         $this->appState = $appState;

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -246,7 +246,7 @@ class Config
      * @throws NoSuchEntityException
      * @throws LocalizedException
      */
-    public function getConfig(string $key, int $scopeId = null, string $scope = ScopeInterface::SCOPE_STORE)
+    public function getConfig(string $key, $scopeId = null, string $scope = ScopeInterface::SCOPE_STORE)
     {
         $config='';
         if (isset($this->config[$key]['path'])) {
@@ -734,7 +734,7 @@ class Config
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function getAppKey(int $scopeId = null, string $scope = ScopeInterface::SCOPE_STORE)
+    public function getAppKey($scopeId = null, string $scope = ScopeInterface::SCOPE_STORE)
     {
         return $this->getConfig('app_key', $scopeId, $scope);
     }
@@ -748,7 +748,7 @@ class Config
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function getSecret(int $scopeId = null, string $scope = ScopeInterface::SCOPE_STORE)
+    public function getSecret($scopeId = null, string $scope = ScopeInterface::SCOPE_STORE)
     {
         return (($secret = $this->getConfig('secret', $scopeId, $scope))) ? $this->encryptor->decrypt($secret) : null;
     }
@@ -762,7 +762,7 @@ class Config
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function isAppKeyAndSecretSet(int $scopeId = null, string $scope = ScopeInterface::SCOPE_STORE): bool
+    public function isAppKeyAndSecretSet($scopeId = null, string $scope = ScopeInterface::SCOPE_STORE): bool
     {
         return $this->getAppKey($scopeId, $scope) && $this->getSecret($scopeId, $scope);
     }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-core",
     "description": "Yotpo Reviews core extension for Magento2",
-    "version": "4.3.3",
+    "version": "4.3.4",
     "license": [
         "OSL-3.0",
         "AFL-3.0"


### PR DESCRIPTION
Since PHP 8.4, if you declare a function parameter with a specific non-nullable type, you can't assign `null` to it as a default value.
PHP 7.?? adds support for declaring optional parameters, but this module should also work for earlier PHP versions (`5.6.0`) 🙃, so I removed the type declarations of these parameters all together.