### PR TITLE
Fix incorrect DB schema attributes preventing setup upgrade completion on Magento 2.4.6-p9

### DIFF
--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -8,13 +8,13 @@
                 comment="Product Row ID"/>
         <column xsi:type="int" name="store_id" unsigned="true" nullable="false" identity="false"
                 comment="Store ID"/>
-        <column xsi:type="double" name="yotpo_id" unsigned="true" nullable="false" default="0"
+        <column xsi:type="double" name="yotpo_id" nullable="false" default="0"
                 comment="Api Response Data - Yotpo ID"/>
-        <column xsi:type="double" name="visible_variant_yotpo_id" unsigned="true" nullable="false" default="0"
+        <column xsi:type="double" name="visible_variant_yotpo_id" nullable="false" default="0"
                 comment="Api Response Data - Yotpo ID of visible child products"/>
         <column xsi:type="int" name="yotpo_id_unassign" unsigned="true" nullable="false" identity="false" default="0"
                 comment="Api Response Data - Yotpo ID - Duplicate"/>
-        <column xsi:type="double" name="yotpo_id_parent" unsigned="true" nullable="false" default="0"
+        <column xsi:type="double" name="yotpo_id_parent" nullable="false" default="0"
                 comment="Api Response Data - Parent Yotpo ID"/>
         <column xsi:type="smallint" name="is_deleted" unsigned="true" nullable="false" identity="false" default="0"
                 comment="Is Deleted"/>
@@ -44,7 +44,7 @@
                 comment="Entity ID"/>
         <column xsi:type="int" name="order_id" unsigned="true" nullable="false" identity="false"
                 comment="Order ID"/>
-        <column xsi:type="double" name="yotpo_id" unsigned="true" nullable="true" scale="0" default="0"
+        <column xsi:type="double" name="yotpo_id" nullable="true" scale="0" default="0"
                 comment="Yotpo ID"/>
         <column xsi:type="datetime" name="synced_to_yotpo" nullable="true" comment="Synced to Yotpo"/>
         <column xsi:type="varchar" name="response_code" nullable="true" length="5" comment="Response Code"/>


### PR DESCRIPTION
### Description

We have checks which flag if a module will break 0 downtime deployments due to issues applying schema updates. This module was flagged, and after a deeper dive it was noticed that the `xsi:type="double"` columns had the invalid attribute `unsigned="true"` which was preventing `setup:upgrade` running to completion due to column updates failing.

This PR removes the invalid `unsigned="true"` attribute from the `xsi:type="double"` columns and allows setup upgrade to complete successfully.

### Testing

- On Magento `2.4.6-p9`
- Composer install module and run `bin/magento setup:upgrade`
- Run `bin/magento setup:db:status`
- Confirm that "All modules are up to date." is output