### PR TITLE
[Feature] Sync Order after Shipment saved

### DIFF
--- a/Observer/Order/SalesOrderShipmentSaveAfter.php
+++ b/Observer/Order/SalesOrderShipmentSaveAfter.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Yotpo\Core\Observer\Order;
+
+use Magento\Framework\App\Area;
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Yotpo\Core\Model\Sync\Orders\Processor as OrdersProcessor;
+use Yotpo\Core\Model\Config;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Framework\App\State as AppState;
+
+/**
+ * Class SalesOrderShipmentSaveAfter
+ * Observer is called when shipment is created/updated
+ */
+class SalesOrderShipmentSaveAfter extends OrderMain implements ObserverInterface
+{
+
+    /**
+     * @var CheckoutSession
+     */
+    protected $checkoutSession;
+
+    /**
+     * @var AppState
+     */
+    protected $appState;
+
+    /**
+     * SalesOrderSaveAfter constructor.
+     * @param OrdersProcessor $ordersProcessor
+     * @param Config $yotpoConfig
+     * @param ResourceConnection $resourceConnection
+     * @param CheckoutSession $checkoutSession
+     * @param AppState $appState
+     */
+    public function __construct(
+        OrdersProcessor $ordersProcessor,
+        Config $yotpoConfig,
+        ResourceConnection $resourceConnection,
+        CheckoutSession $checkoutSession,
+        AppState $appState
+    ) {
+        $this->checkoutSession = $checkoutSession;
+        $this->appState = $appState;
+        parent::__construct($ordersProcessor, $yotpoConfig, $resourceConnection);
+    }
+
+    /**
+     * @param Observer $observer
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function execute(Observer $observer)
+    {
+        $areaCode = $this->appState->getAreaCode();
+        $order = $observer->getEvent()->getShipment()->getOrder();
+
+        if ($areaCode !== Area::AREA_ADMINHTML && $order->getCustomerIsGuest()) {
+            $acceptsSmsMarketing = $this->checkoutSession->getYotpoSmsMarketing();
+            $this->ordersProcessor->updateOrderAttribute(
+                [$order->getEntityId()],
+                'yotpo_accepts_sms_marketing',
+                $acceptsSmsMarketing ?: 0
+            );
+        }
+
+        if ($order->getEntityId()) {
+            $this->processOrderSync($order);
+        }
+    }
+}

--- a/Observer/Order/SalesOrderShipmentSaveAfter.php
+++ b/Observer/Order/SalesOrderShipmentSaveAfter.php
@@ -15,6 +15,8 @@ class SalesOrderShipmentSaveAfter extends OrderMain implements ObserverInterface
 {
     /**
      * @param Observer $observer
+     *
+     * @return void
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */

--- a/Observer/Order/SalesOrderShipmentSaveAfter.php
+++ b/Observer/Order/SalesOrderShipmentSaveAfter.php
@@ -2,16 +2,10 @@
 
 namespace Yotpo\Core\Observer\Order;
 
-use Magento\Framework\App\Area;
-use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
-use Yotpo\Core\Model\Sync\Orders\Processor as OrdersProcessor;
-use Yotpo\Core\Model\Config;
-use Magento\Checkout\Model\Session as CheckoutSession;
-use Magento\Framework\App\State as AppState;
 
 /**
  * Class SalesOrderShipmentSaveAfter

--- a/Observer/Order/SalesOrderShipmentSaveAfter.php
+++ b/Observer/Order/SalesOrderShipmentSaveAfter.php
@@ -19,37 +19,6 @@ use Magento\Framework\App\State as AppState;
  */
 class SalesOrderShipmentSaveAfter extends OrderMain implements ObserverInterface
 {
-
-    /**
-     * @var CheckoutSession
-     */
-    protected $checkoutSession;
-
-    /**
-     * @var AppState
-     */
-    protected $appState;
-
-    /**
-     * SalesOrderSaveAfter constructor.
-     * @param OrdersProcessor $ordersProcessor
-     * @param Config $yotpoConfig
-     * @param ResourceConnection $resourceConnection
-     * @param CheckoutSession $checkoutSession
-     * @param AppState $appState
-     */
-    public function __construct(
-        OrdersProcessor $ordersProcessor,
-        Config $yotpoConfig,
-        ResourceConnection $resourceConnection,
-        CheckoutSession $checkoutSession,
-        AppState $appState
-    ) {
-        $this->checkoutSession = $checkoutSession;
-        $this->appState = $appState;
-        parent::__construct($ordersProcessor, $yotpoConfig, $resourceConnection);
-    }
-
     /**
      * @param Observer $observer
      * @throws LocalizedException
@@ -57,17 +26,7 @@ class SalesOrderShipmentSaveAfter extends OrderMain implements ObserverInterface
      */
     public function execute(Observer $observer)
     {
-        $areaCode = $this->appState->getAreaCode();
         $order = $observer->getEvent()->getShipment()->getOrder();
-
-        if ($areaCode !== Area::AREA_ADMINHTML && $order->getCustomerIsGuest()) {
-            $acceptsSmsMarketing = $this->checkoutSession->getYotpoSmsMarketing();
-            $this->ordersProcessor->updateOrderAttribute(
-                [$order->getEntityId()],
-                'yotpo_accepts_sms_marketing',
-                $acceptsSmsMarketing ?: 0
-            );
-        }
 
         if ($order->getEntityId()) {
             $this->processOrderSync($order);

--- a/Observer/Order/SalesOrderShipmentSaveAfter.php
+++ b/Observer/Order/SalesOrderShipmentSaveAfter.php
@@ -20,9 +20,15 @@ class SalesOrderShipmentSaveAfter extends OrderMain implements ObserverInterface
      */
     public function execute(Observer $observer)
     {
-        $order = $observer->getEvent()->getShipment()->getOrder();
+        $shipment = $observer->getEvent()->getShipment();
 
-        if ($order->getEntityId()) {
+        if (!$shipment) {
+            return;
+        }
+
+        $order = $shipment->getOrder();
+
+        if ($order && $order->getEntityId()) {
             $this->processOrderSync($order);
         }
     }

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -24,7 +24,7 @@
         <observer name="yotpo_core_sales_order_payment_save_after"
                   instance="Yotpo\Core\Observer\Order\SalesOrderPaymentSaveAfter" />
     </event>
-    <event name="sales_order_shipment_save_after">
+    <event name="sales_order_shipment_save_commit_after">
         <observer name="yotpo_core_sales_order_shipment_save_after"
                   instance="Yotpo\Core\Observer\Order\SalesOrderShipmentSaveAfter" />
     </event>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -24,6 +24,10 @@
         <observer name="yotpo_core_sales_order_payment_save_after"
                   instance="Yotpo\Core\Observer\Order\SalesOrderPaymentSaveAfter" />
     </event>
+    <event name="sales_order_shipment_save_after">
+        <observer name="yotpo_core_sales_order_shipment_save_after"
+                  instance="Yotpo\Core\Observer\Order\SalesOrderShipmentSaveAfter" />
+    </event>
     <event name="admin_sales_order_address_update">
         <observer name="yotpo_core_admin_sales_order_address_update"
                   instance="Yotpo\Core\Observer\Order\AdminSalesOrderAddressUpdate" />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new trigger point for real-time order sync on `sales_order_shipment_save_commit_after`, which may increase sync frequency and affect order processing timing if shipments are saved/updated repeatedly.
> 
> **Overview**
> Adds an order-shipment observer (`SalesOrderShipmentSaveAfter`) and wires it to `sales_order_shipment_save_commit_after` so that creating/updating a shipment flags the order for re-sync and optionally triggers real-time order processing via `processOrderSync`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0094558d2b51d56e44224af1f54f6dcbe7d83852. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->