### PR TITLE
fix(orders):sync fulfillment data on shipment creation

### DIFF
--- a/Observer/Order/SalesOrderShipmentSaveAfter.php
+++ b/Observer/Order/SalesOrderShipmentSaveAfter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Yotpo\Core\Observer\Order;
+
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+
+/**
+ * Class SalesOrderShipmentSaveAfter
+ * Observer is called when a shipment is created, so the order is re-synced with fulfillment data
+ */
+class SalesOrderShipmentSaveAfter extends OrderMain implements ObserverInterface
+{
+    /**
+     * @param Observer $observer
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        $shipment = $observer->getEvent()->getShipment();
+        if (!$shipment) {
+            return;
+        }
+        $order = $shipment->getOrder();
+        if ($order && $order->getEntityId()) {
+            $order->setData(self::SYNCED_TO_YOTPO_ORDER, 0);
+            $this->processOrderSync($order);
+        }
+    }
+}

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -28,6 +28,10 @@
         <observer name="yotpo_core_admin_sales_order_address_update"
                   instance="Yotpo\Core\Observer\Order\AdminSalesOrderAddressUpdate" />
     </event>
+    <event name="sales_order_shipment_save_after">
+        <observer name="yotpo_core_sales_order_shipment_save_after"
+                  instance="Yotpo\Core\Observer\Order\SalesOrderShipmentSaveAfter" />
+    </event>
     <event name="catalog_category_save_after">
         <observer name="yotpo_core_category_save"
                   instance="Yotpo\Core\Observer\Category\SaveAfter" />


### PR DESCRIPTION
## Re-sync orders to Yotpo with fulfillment data after shipment

### Problem
When an order was shipped, nothing reset `synced_to_yotpo_order` back to `0`, so the cron never re-synced the order with its fulfillment details.

A first attempt to fix the issue was to add a `sales_order_shipment_save_after` observer that reset the flag via a direct SQL `UPDATE`, but the flag stayed `1`. Root cause: in `Magento\Sales\Model\ShipOrder::createShipment()`, the order is loaded into memory (flag `1`), the shipment is saved (firing our observer, which sets the DB to `0`), and then core immediately calls `orderRepository->save($order)` on that same in-memory object — re-persisting the stale `1` and overwriting our reset. A raw SQL update never touches the already-loaded PHP object, so the subsequent save silently reverted it.

### Fix
- Added `Observer/Order/SalesOrderShipmentSaveAfter.php` (extends `OrderMain`) wired to `sales_order_shipment_save_after` in `etc/events.xml`.
- The observer resolves the order from the shipment and, before calling the existing `processOrderSync()`, also sets the flag on the **in-memory** order object: `$order->setData('synced_to_yotpo_order', 0)`. Because `$shipment->getOrder()` is the same instance core saves at the end of `createShipment()`, the reset now survives that final save. `processOrderSync()` still handles the DB update, marks the `yotpo_orders_sync` row re-syncable, and triggers real-time sync when enabled.

### Result
Shipping an order resets `synced_to_yotpo_order` to `0`; real-time sync runs immediately if enabled, otherwise the cron re-syncs the order — this time including fulfillment data — and flips the flag back to `1` on success. No core files were modified; fulfillment-building and cron logic are untouched.