### PR TITLE
feat(comp):adobe commerce cloud 2.4.9 compatibility updates

### DIFF
--- a/Console/Command/ResetYotpoSync.php
+++ b/Console/Command/ResetYotpoSync.php
@@ -81,7 +81,7 @@ class ResetYotpoSync extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $options = [
             new InputOption(
@@ -108,11 +108,10 @@ class ResetYotpoSync extends Command
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return $this|int
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->init();
 
@@ -123,12 +122,12 @@ class ResetYotpoSync extends Command
             $storeIds = $this->config->getAllStoreIds();
         }
         if (!$storeIds) {
-            return $this;
+            return Command::FAILURE;
         }
         foreach ($storeIds as $storeId) {
             $yotpoEntityInput = $input->getOption(self::YOTPO_ENTITY);
             if (!$yotpoEntityInput) {
-                return $this;
+                return Command::FAILURE;
             }
             if (!is_array($yotpoEntityInput)) {
                 $yotpoEntityInput = [$yotpoEntityInput];
@@ -136,7 +135,7 @@ class ResetYotpoSync extends Command
             $this->resetYotpoSyncByEntity($yotpoEntityInput, $storeId, $output);
         }
 
-        return $this;
+        return Command::SUCCESS;
     }
 
     /**

--- a/Console/Command/RetryYotpoSync.php
+++ b/Console/Command/RetryYotpoSync.php
@@ -96,7 +96,7 @@ class RetryYotpoSync extends Command
      *
      * @return void
      */
-    protected function configure()
+    protected function configure(): void
     {
         $options = [
             new InputOption(
@@ -123,11 +123,10 @@ class RetryYotpoSync extends Command
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return $this|int
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
             $this->init();
@@ -138,17 +137,17 @@ class RetryYotpoSync extends Command
             } else {
                 $yotpoEntityInput = $input->getOption(self::YOTPO_ENTITY);
                 if (!$yotpoEntityInput) {
-                    return 1;
+                    return Command::FAILURE;
                 }
                 if (!is_array($yotpoEntityInput)) {
                     $yotpoEntityInput = [$yotpoEntityInput];
                 }
                 $this->retryYotpoSync($yotpoEntityInput, $output);
             }
-            return 0;
+            return Command::SUCCESS;
         } catch (\Exception $e) {
             $output->writeln('Resync command failed: ' . $e->getMessage());
-            return 1;
+            return Command::FAILURE;
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Magento 2.2+ (Module version 2.8.0 and above)
 
 Magento 2.4.8 (Module version 4.3.2 and above)
 
+Magento 2.4.9 (Module version 4.3.7 and above)
+
 ## ✓ Install via [composer](https://getcomposer.org/download/) (recommended)
 Run the following command under your Magento 2 root dir:
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-core",
     "description": "Yotpo Reviews core extension for Magento2",
-    "version": "4.3.6",
+    "version": "4.3.7",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_Core" setup_version="4.3.2">
+    <module name="Yotpo_Core" setup_version="4.3.7">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
That's the [only actionable item](https://developer.adobe.com/commerce/php/development/backward-incompatible-changes/#symfony-dependencies-upgraded-to-latest-lts-version) from the changelog