### PR TITLE
fix(console):use proper return types and Command constants in sync commands

### DIFF
--- a/Console/Command/ResetYotpoSync.php
+++ b/Console/Command/ResetYotpoSync.php
@@ -108,11 +108,11 @@ class ResetYotpoSync extends Command
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return $this|int
+     * @return int
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->init();
 
@@ -123,12 +123,12 @@ class ResetYotpoSync extends Command
             $storeIds = $this->config->getAllStoreIds();
         }
         if (!$storeIds) {
-            return $this;
+            return Command::FAILURE;
         }
         foreach ($storeIds as $storeId) {
             $yotpoEntityInput = $input->getOption(self::YOTPO_ENTITY);
             if (!$yotpoEntityInput) {
-                return $this;
+                return Command::FAILURE;
             }
             if (!is_array($yotpoEntityInput)) {
                 $yotpoEntityInput = [$yotpoEntityInput];
@@ -136,7 +136,7 @@ class ResetYotpoSync extends Command
             $this->resetYotpoSyncByEntity($yotpoEntityInput, $storeId, $output);
         }
 
-        return $this;
+        return Command::SUCCESS;
     }
 
     /**

--- a/Console/Command/RetryYotpoSync.php
+++ b/Console/Command/RetryYotpoSync.php
@@ -123,11 +123,11 @@ class RetryYotpoSync extends Command
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return $this|int
+     * @return int
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
             $this->init();
@@ -138,17 +138,17 @@ class RetryYotpoSync extends Command
             } else {
                 $yotpoEntityInput = $input->getOption(self::YOTPO_ENTITY);
                 if (!$yotpoEntityInput) {
-                    return 1;
+                    return Command::FAILURE;
                 }
                 if (!is_array($yotpoEntityInput)) {
                     $yotpoEntityInput = [$yotpoEntityInput];
                 }
                 $this->retryYotpoSync($yotpoEntityInput, $output);
             }
-            return 0;
+            return Command::SUCCESS;
         } catch (\Exception $e) {
             $output->writeln('Resync command failed: ' . $e->getMessage());
-            return 1;
+            return Command::FAILURE;
         }
     }
 


### PR DESCRIPTION
# Jira Link
https://yotpoent.atlassian.net/browse/TS-15

# Summary
Fixes a major breakdown bug where yotpo on-site widgets module is incompatible with Magento 2.4.9 and breaks the entire merchant store.