### PR TITLE
feat(core):bump version to get compatible with Magento 2.4.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Magento 2.2+ (Module version 2.8.0 and above)
 
 Magento 2.4.8 (Module version 4.3.2 and above)
 
+Magento 2.4.9 (Module version 4.3.7 and above)
+
 ## ✓ Install via [composer](https://getcomposer.org/download/) (recommended)
 Run the following command under your Magento 2 root dir:
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-core",
     "description": "Yotpo Reviews core extension for Magento2",
-    "version": "4.3.6",
+    "version": "4.3.7",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_Core" setup_version="4.3.2">
+    <module name="Yotpo_Core" setup_version="4.3.7">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
### Jira Link
https://yotpoent.atlassian.net/browse/TS-15

### Summary
Bumping version in order to make yotpo on-site widget compatible with Magento 2.4.9