### PR TITLE
fix(http): preserve real API status when Guzzle error message contains CR/LF

### DIFF
--- a/Http/Yclient.php
+++ b/Http/Yclient.php
@@ -123,13 +123,13 @@ class Yclient
             try {
                 $response = $this->responseFactory->create([
                     'status' => $exception->getCode(),
-                    'reason' => $exception->getMessage()
+                    'reason' => $this->sanitizeReasonPhrase($exception->getMessage())
                 ]);
                 $exceptionCode = $exception->getCode();
-            } catch (\InvalidArgumentException $exception) {
+            } catch (\InvalidArgumentException $responseException) {
                 $response = $this->responseFactory->create([
                     'status' => Config::RESPONSE_CODE_FOR_UNKNOWN_ERRORS,
-                    'reason' => $exception->getMessage()
+                    'reason' => $this->sanitizeReasonPhrase($responseException->getMessage())
                 ]);
                 $exceptionCode = $exception->getCode();
             }
@@ -138,6 +138,21 @@ class Yclient
             $this->yotpoApiLogger->infoLog($exceptionMessage, $exceptionData);
         }
         return $response;
+    }
+
+    /**
+     * Collapse whitespace so the value is safe to use as a PSR-7 reason phrase.
+     *
+     * PSR-7 (guzzlehttp/psr7 >= 2.12) rejects CR/LF in the reason phrase and throws
+     * \InvalidArgumentException. Guzzle exception messages are multi-line, so they must
+     * be flattened before being passed to responseFactory->create().
+     *
+     * @param string $reason
+     * @return string
+     */
+    private function sanitizeReasonPhrase(string $reason): string
+    {
+        return trim(preg_replace('/\s+/', ' ', $reason));
     }
 
     /**


### PR DESCRIPTION
**Ticket:** [TS-43](https://yotpoent.atlassian.net/browse/TS-43)

## Problem

After the module upgrade pulled in `guzzlehttp/psr7 >= 2.12`, failed Yotpo API calls started logging `response code = 0` / `Reason phrase must not contain CR or LF characters` instead of the real status + body.

psr7 2.12 made the PSR-7 `Response` constructor reject CR/LF in the reason phrase. `Yclient::doRequest()` feeds the raw (multi-line) Guzzle exception message into `'reason'`, so the constructor now throws `\InvalidArgumentException`. The inner `catch` then reused the `$exception` variable (clobbering the original Guzzle exception) and hard-coded the status to `RESPONSE_CODE_FOR_UNKNOWN_ERRORS` (500).

**Impact:** real statuses (`406`, `409`, …) were masked as `500`, which silently broke recovery paths that branch on the real status — notably the product 409 "already-exists" recovery (`POST → GET yotpo_id → PATCH`) — so order sync failed.

Note: this was a latent bug. Before the psr7 upgrade the inner `catch` never fired (the old constructor accepted CR/LF), so the shadowing + hard-coded 500 were dormant. The upgrade's stricter validation is what activated them.

## Fix (minimal)

- Flatten the reason phrase via `sanitizeReasonPhrase()` so building the PSR-7 response no longer throws and the real status/message survive.
- Rename the inner catch variable to `$responseException` so the original Guzzle exception is never shadowed (this also makes the trailing `response code` / `response =` log lines report the real Guzzle status/message).

## Testing

Verified on Magento 2.4.8 / module 4.3.7:
- A forced `406` now logs the real status and Yotpo's response body (previously `response code = 0`).
- The product `409` recovery (`GET → PATCH`) runs and repairs the missing `yotpo_id`, so the order syncs (order stored with `response_code = 201`).
- PHPCS (Magento2 standard) on the changed file: **0 errors, 10 warnings — identical to `master`** (no new offenses).


[TS-43]: https://yotpoent.atlassian.net/browse/TS-43?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ