### PR TITLE
feat(core):bump version to 4.3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "yotpo/module-yotpo-core",
     "description": "Yotpo Reviews core extension for Magento2",
-    "version": "4.3.7",
+    "version": "4.3.8",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Yotpo_Core" setup_version="4.3.7">
+    <module name="Yotpo_Core" setup_version="4.3.8">
         <sequence>
             <module name="Magento_Catalog"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
Version bump to release **TS-43** (#244 — Yclient error masking fix).

- `composer.json` — 4.3.7 → 4.3.8
- `etc/module.xml` — `setup_version` 4.3.7 → 4.3.8

No README change: the line added in 4.3.7 was for new Magento 2.4.9 compatibility, nothing comparable here.

---

### Release chain — this is repo 1 of 4

| # | repo | version | pins |
|---|---|---|---|
| **1** | **core** | **4.3.8** | — |
| 2 | reviews | 4.3.8 | core 4.3.8 |
| 3 | messaging | 4.3.7 | core 4.3.8 |
| 4 | combined | 4.3.10 | reviews 4.3.8, messaging 4.3.7 |

⚠️ **Tag `4.3.8` only after #244 is also merged**, then confirm it on packagist before repo 2 is tagged. Repos 2–4 pin versions that must already be published — on 2026-07-22 a pin to a non-existent `messaging: 4.3.7` burned combined 4.3.8 permanently.