### PR TITLE
fix(orders): scope line item product ids to the order being prepared

### DIFF
--- a/Model/Sync/Orders/Data.php
+++ b/Model/Sync/Orders/Data.php
@@ -140,6 +140,7 @@ class Data extends AbstractData
      */
     public function prepareData($order, $syncType, $yotpoOrderObject)
     {
+        $this->lineItemsProductIds = [];
         $billingAddress = $order->getBillingAddress();
         $shippingAddress = $order->getShippingAddress();
         $orderStatus = $order->getStatus();
@@ -413,13 +414,17 @@ class Data extends AbstractData
     }
 
     /**
-     * Get the product ids
+     * Get the product ids of the order most recently passed to prepareData().
+     *
+     * Reset by prepareData() on every call - this class is a DI singleton, so without
+     * that reset the ids accumulate across the whole batch and the product-sync gate in
+     * Orders\Processor::syncOrder() ends up gating each order on every product seen before it.
      *
      * @return array<mixed>
      */
     public function getLineItemsIds()
     {
-        return $this->lineItemsProductIds;
+        return array_values(array_unique($this->lineItemsProductIds));
     }
 
     /**

--- a/Test/Unit/Model/Sync/Orders/DataTest.php
+++ b/Test/Unit/Model/Sync/Orders/DataTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Yotpo\Core\Test\Unit\Model\Sync\Orders;
+
+use Magento\Sales\Model\Order;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Yotpo\Core\Helper\Data as CoreHelper;
+use Yotpo\Core\Model\Sync\Orders\Data;
+
+/**
+ * Covers the per-order scoping of the line item product ids.
+ *
+ * Data is a DI singleton shared by every order in a cron batch, so the ids collected while
+ * building a payload must belong to the order currently being prepared - see
+ * Orders\Processor::syncOrder(), which uses them to gate the order on a product sync.
+ */
+class DataTest extends TestCase
+{
+    /**
+     * Stubs everything prepareData() reaches out to except prepareLineItems(), which each
+     * test configures itself, leaving prepareData() real.
+     *
+     * @return Data&MockObject
+     */
+    private function createData()
+    {
+        $data = $this->getMockBuilder(Data::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'getYotpoOrderStatus',
+                'getYotpoPaymentStatus',
+                'prepareCustomerData',
+                'prepareLineItems',
+                'prepareFulfillments',
+            ])
+            ->getMock();
+
+        $data->method('getYotpoOrderStatus')->willReturn('success');
+        $data->method('getYotpoPaymentStatus')->willReturn('paid');
+        $data->method('prepareCustomerData')->willReturn([]);
+        $data->method('prepareFulfillments')->willReturn([]);
+
+        $store = $this->createMock(Store::class);
+        $store->method('getBaseUrl')->willReturn('https://example.test/');
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStore')->willReturn($store);
+
+        $coreHelper = $this->createMock(CoreHelper::class);
+        $coreHelper->method('formatDate')->willReturn('2026-08-27T00:00:00Z');
+
+        $this->setProperty($data, 'storeManager', $storeManager);
+        $this->setProperty($data, 'coreHelper', $coreHelper);
+
+        return $data;
+    }
+
+    /**
+     * @return Order&MockObject
+     */
+    private function createOrder()
+    {
+        $order = $this->createMock(Order::class);
+        $order->method('getStatus')->willReturn('processing');
+        $order->method('getBillingAddress')->willReturn(null);
+        $order->method('getShippingAddress')->willReturn(null);
+        $order->method('getPayment')->willReturn(null);
+
+        return $order;
+    }
+
+    /**
+     * @param object $object
+     * @param string $name
+     * @param mixed $value
+     * @return void
+     */
+    private function setProperty($object, string $name, $value): void
+    {
+        (new \ReflectionProperty(Data::class, $name))->setValue($object, $value);
+    }
+
+    public function testGetLineItemsIdsRemovesDuplicates(): void
+    {
+        $data = $this->createData();
+        $data->method('prepareLineItems')->willReturn([]);
+        $this->setProperty($data, 'lineItemsProductIds', [5, 5, 7, 5]);
+
+        $this->assertSame([5, 7], $data->getLineItemsIds());
+    }
+
+    public function testGetLineItemsIdsReturnsSequentiallyIndexedList(): void
+    {
+        $data = $this->createData();
+        $data->method('prepareLineItems')->willReturn([]);
+        $this->setProperty($data, 'lineItemsProductIds', [10, 10, 20]);
+
+        // array_unique alone preserves the original keys, leaving a gappy array.
+        $this->assertSame([0, 1], array_keys($data->getLineItemsIds()));
+    }
+
+    public function testPrepareDataDiscardsProductIdsFromPreviousOrders(): void
+    {
+        $data = $this->createData();
+        $data->method('prepareLineItems')->willReturn([]);
+        $this->setProperty($data, 'lineItemsProductIds', [99, 100]);
+
+        $data->prepareData($this->createOrder(), 'update', []);
+
+        $this->assertSame(
+            [],
+            $data->getLineItemsIds(),
+            'prepareData() must clear ids collected for earlier orders in the batch'
+        );
+    }
+
+    public function testPrepareDataKeepsOnlyTheCurrentOrdersProductIds(): void
+    {
+        $data = $this->createData();
+        $this->setProperty($data, 'lineItemsProductIds', [99, 100]);
+
+        // Stands in for prepareLineItems(), which appends - it never assigns.
+        $data->method('prepareLineItems')->willReturnCallback(
+            function () use ($data) {
+                $this->setProperty($data, 'lineItemsProductIds', array_merge($data->getLineItemsIds(), [42]));
+                return [];
+            }
+        );
+
+        $data->prepareData($this->createOrder(), 'update', []);
+
+        $this->assertSame([42], $data->getLineItemsIds());
+    }
+}


### PR DESCRIPTION
## Ticket
https://yotpoent.atlassian.net/browse/TS-41
## What's wrong

`Orders\Data` is a shared singleton, so one instance handles every order in a cron batch. It collects the product ids of the order it is building into `$lineItemsProductIds`, but that list is only ever appended to — nothing clears it.

`Processor::syncOrder()` then reads it back and treats it as "the products in this order", using it to check those products exist in Yotpo before sending the order:

```php
$productIds = $this->data->getLineItemsIds();
if ($productIds) {
    $isProductSyncSuccess = $this->catalogProcessor->syncProducts($productIds, $visibleItems, $storeId);
    if (!$isProductSyncSuccess) { /* 'Products sync failed' */ return []; }
}
```

Because the list keeps growing, each order is checked against every product seen earlier in the batch. Two consequences:

- **One product that can't sync blocks every order after it**, even orders that don't contain it.
- **The batch gets slow.** The lookup query grows per order, and each already-failed product is retried against the API once more for every remaining order.

## The fix

- Clear the list at the start of `prepareData()`. That covers the cron path, the real-time path and the retry recursion, so no caller has to remember to do it.
- Deduplicate in the getter, since `prepareLineItems()` can run twice for the same order. This was only wasted work, not a wrong result — the clearing is the real fix.

**Not changed:** `parentProductIds` and `magentoParentProductIds` also accumulate, but deliberately — `prepareParentData()` fills them once for the whole batch and they're read unguarded, so clearing them per order would break every order after the first.

## Testing

Reproduced on a local store by making one product unsyncable, then running the same batch with and without the fix. Orders are processed newest-first and the bad product is in order 21:

| order | with fix | without fix |
|---|---|---|
| 22 | ok | ok |
| 21 (has the bad product) | fails | fails |
| 20 | ok | **fails** |
| 19 | ok | **fails** |
| 16 | ok | **fails** |
| 14 | ok | **fails** |
| 13 | ok | **fails** |

Order 22 passes either way because it's processed before the bad product enters the list.

Also adds `Test/Unit` — the first unit tests in this module. Nothing to configure; Magento's unit suite already picks up `vendor/*/module-*/Test/Unit`:

```
vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist \
  vendor/yotpo/module-yotpo-core/Test/Unit/Model/Sync/Orders/DataTest.php
```

All 4 pass with this change and all 4 fail without it.

---

One of several PRs on this ticket. They ship together under a single version bump in its own PR, so there's no version change here.