### PR TITLE
fix(orders): fulfillment-flag latch 

### DIFF
--- a/Model/Sync/Orders/Data.php
+++ b/Model/Sync/Orders/Data.php
@@ -441,8 +441,11 @@ class Data extends AbstractData
             $fulfillments = [];
             $mappedOrderStatus = $this->getYotpoOrderStatus($order->getStatus());
 
-            if ($syncType == 'update' && $yotpoOrderObject[$order->getId()]['yotpo_id']) {
-                $isFulfillmentBasedOnShipping = $yotpoOrderObject[$order->getId()]['is_fulfillment_based_on_shipment'];
+            if ($syncType == 'update' && !empty($yotpoOrderObject[$order->getId()]['yotpo_id'])) {
+                $storedFulfillmentFlag = $yotpoOrderObject[$order->getId()]['is_fulfillment_based_on_shipment'] ?? null;
+                $isFulfillmentBasedOnShipping = ($storedFulfillmentFlag === null || $storedFulfillmentFlag === '')
+                    ? $this->config->getConfig('is_fulfillment_based_on_shipment')
+                    : $storedFulfillmentFlag;
             } else {
                 $isFulfillmentBasedOnShipping = $this->config->getConfig('is_fulfillment_based_on_shipment');
             }

--- a/Model/Sync/Reset/Orders.php
+++ b/Model/Sync/Reset/Orders.php
@@ -11,6 +11,7 @@ class Orders extends Main
     const ORDERS_DATA_LIMIT = 300;
     const YOTPO_ENTITY_NAME = 'order';
     const SYNCED_TO_YOTPO_ORDER_COLUMN = 'synced_to_yotpo_order';
+    const FULFILLMENT_FLAG_COLUMN = 'is_fulfillment_based_on_shipment';
 
     /**
      * @return array <string>
@@ -103,5 +104,37 @@ class Orders extends Main
             $connection->quoteInto('order_id IN (?)', $orderIds)
         ];
         $connection->delete($tableName, $whereConditions);
+    }
+
+    /**
+     * Clear the per-order fulfillment-flag pin, store-scoped via sales_order (yotpo_orders_sync
+     * itself has no store_id column). A merchant changing shipments_flag is a deliberate signal
+     * to re-derive fulfillment for already-synced orders on their next sync, rather than staying
+     * latched to whatever was recorded under the old setting - see
+     * Model/Sync/Orders/Data.php::prepareFulfillments().
+     *
+     * @param int $storeId
+     * @return void
+     */
+    public function clearFulfillmentFlagPins($storeId)
+    {
+        $connection = $this->resourceConnection->getConnection();
+        $table = $this->resourceConnection->getTableName(self::ORDERS_TABLE);
+        $select = $connection->select()
+            ->from($table, 'entity_id')
+            ->where('store_id', $storeId);
+
+        $offset = 0;
+        do {
+            $entityIds = $connection->fetchCol($select->limit(self::ORDERS_DATA_LIMIT, $offset));
+            if ($entityIds) {
+                $connection->update(
+                    $this->resourceConnection->getTableName(self::ORDERS_SYNC_TABLE),
+                    [self::FULFILLMENT_FLAG_COLUMN => null],
+                    [$connection->quoteInto('order_id IN (?)', $entityIds)]
+                );
+            }
+            $offset += self::ORDERS_DATA_LIMIT;
+        } while ($entityIds);
     }
 }

--- a/Model/Sync/ResetEntitiesSync.php
+++ b/Model/Sync/ResetEntitiesSync.php
@@ -75,4 +75,13 @@ class ResetEntitiesSync
     {
         $this->customersReset->resetSync($storeId);
     }
+
+    /**
+     * @param int $storeId
+     * @return void
+     */
+    public function clearOrdersFulfillmentFlag($storeId)
+    {
+        $this->ordersReset->clearFulfillmentFlagPins($storeId);
+    }
 }

--- a/Observer/Config/Save.php
+++ b/Observer/Config/Save.php
@@ -95,6 +95,38 @@ class Save extends Main implements ObserverInterface
         $this->doYotpoApiKeyValidation($observer);
         $this->catalogMapping->doYotpoCatalogMappingChanges($observer);
         $this->cronFrequency->doCronFrequencyChanges($observer);
+        $this->doShipmentsFlagChanges($observer);
+    }
+
+    /**
+     * A merchant changing shipments_flag is a deliberate signal to re-derive fulfillment for
+     * already-synced orders. Clear the per-order pin so Data::prepareFulfillments() falls back
+     * to the new config value on the next sync, instead of staying latched to whatever was
+     * recorded under the old setting.
+     *
+     * @param Observer $observer
+     * @return void
+     */
+    public function doShipmentsFlagChanges(Observer $observer)
+    {
+        $changedPaths = (array)$observer->getEvent()->getChangedPaths();
+        if ($changedPaths && $this->isShipmentsFlagChanged($changedPaths)) {
+            $scopeId = $this->getScopes($observer)['scope_id'];
+            if ($scopeId) {
+                $this->syncReset->clearOrdersFulfillmentFlag($scopeId);
+            }
+        }
+    }
+
+    /**
+     * @param array <string> $changedPaths
+     * @return bool
+     */
+    public function isShipmentsFlagChanged($changedPaths = [])
+    {
+        $yotpoKeyPaths = ['is_fulfillment_based_on_shipment'];
+        $commonPaths = $this->getChangedYotpoPaths($changedPaths, $yotpoKeyPaths);
+        return (bool)$commonPaths;
     }
 
     /**

--- a/Test/Unit/Model/Sync/Orders/DataTest.php
+++ b/Test/Unit/Model/Sync/Orders/DataTest.php
@@ -8,6 +8,7 @@ use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Yotpo\Core\Helper\Data as CoreHelper;
+use Yotpo\Core\Model\Config;
 use Yotpo\Core\Model\Sync\Orders\Data;
 
 /**
@@ -63,12 +64,60 @@ class DataTest extends TestCase
     private function createOrder()
     {
         $order = $this->createMock(Order::class);
+        $order->method('getId')->willReturn(5);
         $order->method('getStatus')->willReturn('processing');
         $order->method('getBillingAddress')->willReturn(null);
         $order->method('getShippingAddress')->willReturn(null);
         $order->method('getPayment')->willReturn(null);
+        $order->method('getUpdatedAt')->willReturn('2026-08-27 00:00:00');
+        $order->method('getIncrementId')->willReturn('000000005');
 
         return $order;
+    }
+
+    /**
+     * Stubs everything prepareFulfillments() reaches out to except the flag-resolution logic
+     * under test, leaving prepareFulfillments() itself real. getYotpoOrderStatus() is fixed to
+     * 'success' and prepareLineItems() to a sentinel, so the status-based branch's output is
+     * deterministic and comparable across separate instances (e.g. one built for config "on",
+     * one for config "off").
+     *
+     * @param string $configReturnValue
+     * @return Data&MockObject
+     */
+    private function createDataForFulfillments($configReturnValue)
+    {
+        $data = $this->getMockBuilder(Data::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'getYotpoOrderStatus',
+                'getYotpoPaymentStatus',
+                'prepareCustomerData',
+                'prepareLineItems',
+            ])
+            ->getMock();
+
+        $data->method('getYotpoOrderStatus')->willReturn(Data::YOTPO_STATUS_SUCCESS);
+        $data->method('prepareLineItems')->willReturn(['SENTINEL']);
+
+        $store = $this->createMock(Store::class);
+        $store->method('getBaseUrl')->willReturn('https://example.test/');
+        $storeManager = $this->createMock(StoreManagerInterface::class);
+        $storeManager->method('getStore')->willReturn($store);
+
+        $coreHelper = $this->createMock(CoreHelper::class);
+        $coreHelper->method('formatDate')->willReturn('2026-08-27T00:00:00Z');
+
+        $config = $this->createMock(Config::class);
+        $config->method('getConfig')
+            ->with('is_fulfillment_based_on_shipment')
+            ->willReturn($configReturnValue);
+
+        $this->setProperty($data, 'storeManager', $storeManager);
+        $this->setProperty($data, 'coreHelper', $coreHelper);
+        $this->setProperty($data, 'config', $config);
+
+        return $data;
     }
 
     /**
@@ -132,5 +181,65 @@ class DataTest extends TestCase
         $data->prepareData($this->createOrder(), 'update', []);
 
         $this->assertSame([42], $data->getLineItemsIds());
+    }
+
+    /**
+     * Covers the fulfillment-flag read path: prepareFulfillments() (Data.php:444-448) reads the
+     * stored is_fulfillment_based_on_shipment value with no fallback at all. An order that has
+     * never had an opinion recorded - stored NULL, e.g. via
+     * Main::prepareYotpoTableDataForMissingProducts() - must be treated the same as an order
+     * syncing for the first time, i.e. it must fall back to current config.
+     */
+    public function testPrepareFulfillmentsWithNullStoredFlagMatchesFirstSyncBehavior(): void
+    {
+        $order = $this->createOrder();
+
+        $firstSyncResult = $this->createDataForFulfillments('1')
+            ->prepareFulfillments($order, 'create', []);
+        $nullStoredFlagResult = $this->createDataForFulfillments('1')->prepareFulfillments(
+            $order,
+            'update',
+            [$order->getId() => ['yotpo_id' => 123, 'is_fulfillment_based_on_shipment' => null]]
+        );
+
+        $this->assertSame($firstSyncResult, $nullStoredFlagResult);
+    }
+
+    /**
+     * Same as above for an empty-string stored value - fetchAssoc() never returns one for this
+     * boolean column today, but the read path should not special-case NULL only.
+     */
+    public function testPrepareFulfillmentsWithEmptyStringStoredFlagMatchesFirstSyncBehavior(): void
+    {
+        $order = $this->createOrder();
+
+        $firstSyncResult = $this->createDataForFulfillments('1')
+            ->prepareFulfillments($order, 'create', []);
+        $emptyStoredFlagResult = $this->createDataForFulfillments('1')->prepareFulfillments(
+            $order,
+            'update',
+            [$order->getId() => ['yotpo_id' => 123, 'is_fulfillment_based_on_shipment' => '']]
+        );
+
+        $this->assertSame($firstSyncResult, $emptyStoredFlagResult);
+    }
+
+    /**
+     * Regression guard - a genuinely stored '0' is a real pin, not an unset value, and must keep
+     * winning over current config even after the fallback is added.
+     */
+    public function testPrepareFulfillmentsKeepsStoredZeroFlagEvenWhenConfigIsOn(): void
+    {
+        $order = $this->createOrder();
+
+        $groundTruthConfigOff = $this->createDataForFulfillments('0')
+            ->prepareFulfillments($order, 'create', []);
+        $storedZeroResult = $this->createDataForFulfillments('1')->prepareFulfillments(
+            $order,
+            'update',
+            [$order->getId() => ['yotpo_id' => 123, 'is_fulfillment_based_on_shipment' => '0']]
+        );
+
+        $this->assertSame($groundTruthConfigOff, $storedZeroResult);
     }
 }

--- a/Test/Unit/Observer/Config/SaveTest.php
+++ b/Test/Unit/Observer/Config/SaveTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Yotpo\Core\Test\Unit\Observer\Config;
+
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Yotpo\Core\Model\Config as YotpoConfig;
+use Yotpo\Core\Model\Sync\ResetEntitiesSync as SyncReset;
+use Yotpo\Core\Observer\Config\Save;
+
+/**
+ * Covers the shipments_flag config-change hook: a merchant flipping is_fulfillment_based_on_shipment
+ * is a deliberate signal to re-derive fulfillment for already-synced orders, so the stored
+ * per-order pin (Data.php:444-448) must be cleared rather than left to latch forever.
+ */
+class SaveTest extends TestCase
+{
+    const SHIPMENTS_FLAG_PATH = 'yotpo_core/sync_settings/orders_sync/shipments/shipments_flag';
+    const UNRELATED_PATH = 'yotpo_core/sync_settings/orders_sync/enable_real_time_sync';
+
+    /**
+     * @param SyncReset&MockObject $syncReset
+     * @return Save
+     */
+    private function createSave($syncReset)
+    {
+        $save = $this->getMockBuilder(Save::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([])
+            ->getMock();
+
+        $yotpoConfig = $this->createMock(YotpoConfig::class);
+        $yotpoConfig->method('getConfigPath')
+            ->with('is_fulfillment_based_on_shipment')
+            ->willReturn(self::SHIPMENTS_FLAG_PATH);
+
+        (new \ReflectionProperty(Save::class, 'yotpoConfig'))->setValue($save, $yotpoConfig);
+        (new \ReflectionProperty(Save::class, 'syncReset'))->setValue($save, $syncReset);
+
+        return $save;
+    }
+
+    /**
+     * @param int|null $storeId
+     * @param array <string> $changedPaths
+     * @return Observer
+     */
+    private function createObserver($storeId, $changedPaths)
+    {
+        $event = new Event(['changed_paths' => $changedPaths, 'store' => $storeId]);
+        return new Observer(['event' => $event]);
+    }
+
+    public function testIsShipmentsFlagChangedIsTrueWhenPathPresent(): void
+    {
+        $save = $this->createSave($this->createMock(SyncReset::class));
+
+        $this->assertTrue($save->isShipmentsFlagChanged([self::SHIPMENTS_FLAG_PATH]));
+    }
+
+    public function testIsShipmentsFlagChangedIsFalseWhenPathAbsent(): void
+    {
+        $save = $this->createSave($this->createMock(SyncReset::class));
+
+        $this->assertFalse($save->isShipmentsFlagChanged([self::UNRELATED_PATH]));
+    }
+
+    public function testDoShipmentsFlagChangesClearsThePinForTheChangedStore(): void
+    {
+        $syncReset = $this->createMock(SyncReset::class);
+        $syncReset->expects($this->once())
+            ->method('clearOrdersFulfillmentFlag')
+            ->with(7);
+
+        $save = $this->createSave($syncReset);
+
+        $save->doShipmentsFlagChanges($this->createObserver(7, [self::SHIPMENTS_FLAG_PATH]));
+    }
+
+    public function testDoShipmentsFlagChangesDoesNothingForAnUnrelatedSetting(): void
+    {
+        $syncReset = $this->createMock(SyncReset::class);
+        $syncReset->expects($this->never())->method('clearOrdersFulfillmentFlag');
+
+        $save = $this->createSave($syncReset);
+
+        $save->doShipmentsFlagChanges($this->createObserver(7, [self::UNRELATED_PATH]));
+    }
+
+    public function testDoShipmentsFlagChangesDoesNothingWithoutAResolvedStoreScope(): void
+    {
+        // No store/website on the event -> getScopes() resolves scope_id to 0 (default scope).
+        // Matches the existing app-key-change guard (isYotpoAppKeyChanged path): scope 0 is
+        // skipped rather than guessed at.
+        $syncReset = $this->createMock(SyncReset::class);
+        $syncReset->expects($this->never())->method('clearOrdersFulfillmentFlag');
+
+        $save = $this->createSave($syncReset);
+
+        $save->doShipmentsFlagChanges($this->createObserver(null, [self::SHIPMENTS_FLAG_PATH]));
+    }
+}


### PR DESCRIPTION
## Ticket
https://yotpoent.atlassian.net/browse/TS-41

## What's wrong

`is_fulfillment_based_on_shipment` is a per-order flag stored on `yotpo_orders_sync` that decides whether an order's fulfillment payload is built from real Magento shipment records or a coarse status-based guess. Two bugs in how it's read and maintained:

`Data::prepareFulfillments()` reads the stored value with no fallback at all:

```php
if ($syncType == 'update' && $yotpoOrderObject[$order->getId()]['yotpo_id']) {
    $isFulfillmentBasedOnShipping = $yotpoOrderObject[$order->getId()]['is_fulfillment_based_on_shipment'];
}
```

A genuinely unset value (`NULL`, written by `prepareYotpoTableDataForMissingProducts()` for orders whose products failed to sync) is treated the same as an intentional "off", regardless of what current config says.

And nothing ever clears that stored value. Once an order syncs under one setting, it stays pinned to it forever - even after a merchant fixes the config, already-synced orders keep sending the old fulfillment on every future sync.

## The fix

- `Data::prepareFulfillments()` falls back to current config when the stored value is `null`/`''`. A real stored `0` or `1` still wins - it's an intentional pin, not a bug.
- `Observer\Config\Save` clears the stored value for a store's orders when `shipments_flag` changes, mirroring the existing app-key-change handling (`isYotpoAppKeyChanged` → `syncReset`).

Together, this is what makes a historical order recoverable: once a merchant corrects `shipments_flag` and the order gets requeued, it now re-derives fulfillment from current config instead of staying latched to whatever was recorded under the old setting.

## Testing

Reproduced on a local store: forced a real order's stored flag to `0` with config saying shipment-based on - it kept sending the status-based guess (`fulfillment_date` = now, no `shipment_info`), confirming the pin is respected. Then fired the actual admin config-save event through the real observer wiring - the stored flag cleared, and the same order's next sync sent the real shipment's date, items and `shipment_info` instead of the guess.

```
vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist \
  vendor/yotpo/module-yotpo-core/Test/Unit/Model/Sync/Orders/DataTest.php \
  vendor/yotpo/module-yotpo-core/Test/Unit/Observer/Config/SaveTest.php
```

12 pass with this change; the 2 covering the missing fallback fail without it.

---

Stacked on #246. One of several PRs on this ticket - they ship together under a single version bump in its own PR, so there's no version change here.