### PR TITLE
fix(orders): defer real-time shipment sync until after commit

### DIFF
--- a/Observer/Order/OrderMain.php
+++ b/Observer/Order/OrderMain.php
@@ -53,12 +53,35 @@ class OrderMain
      */
     public function processOrderSync($order)
     {
+        $this->reQueueOrder($order);
+        $this->syncOrderNow($order);
+    }
+
+    /**
+     * Re-queue the order for its next sync. Safe to call from inside any transaction - only
+     * touches sync bookkeeping, never reads order or shipment data.
+     *
+     * @param Order $order
+     * @return void
+     */
+    protected function reQueueOrder($order)
+    {
         $this->ordersProcessor->updateOrderAttribute(
             [$order->getId()],
             self::SYNCED_TO_YOTPO_ORDER,
             0
         );
         $this->updateOrderSyncTable($order->getId());
+    }
+
+    /**
+     * @param Order $order
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @return void
+     */
+    protected function syncOrderNow($order)
+    {
         if ($this->yotpoConfig->isRealTimeOrdersSyncActive($order->getStoreId())) {
             $this->ordersProcessor->processOrder($order);
         }

--- a/Observer/Order/SalesOrderShipmentSaveAfter.php
+++ b/Observer/Order/SalesOrderShipmentSaveAfter.php
@@ -2,17 +2,55 @@
 
 namespace Yotpo\Core\Observer\Order;
 
+use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Yotpo\Core\Model\Config;
+use Yotpo\Core\Model\Sync\Orders\Logger as YotpoOrdersLogger;
+use Yotpo\Core\Model\Sync\Orders\Processor as OrdersProcessor;
 
 /**
  * Class SalesOrderShipmentSaveAfter
- * Observer is called when a shipment is created, so the order is re-synced with fulfillment data
+ * Observer is called when a shipment is created, so the order is re-synced with fulfillment data.
+ *
+ * The re-queue (synced_to_yotpo_order -> 0, response_code -> '000') runs synchronously - it only
+ * touches sync bookkeeping. The real-time sync itself is deferred to the shipment's transaction
+ * commit callback, because this observer runs on sales_order_shipment_save_after, while the
+ * transaction is still open and the shipment's line items are not yet persisted.
  */
 class SalesOrderShipmentSaveAfter extends OrderMain implements ObserverInterface
 {
+    /**
+     * @var YotpoOrdersLogger
+     */
+    protected $yotpoOrdersLogger;
+
+    /**
+     * Order ids already scheduled for a deferred real-time sync in this request, so two
+     * shipments saved for the same order in one request don't schedule the sync twice.
+     *
+     * @var array<int|string, bool>
+     */
+    private $realTimeSyncQueued = [];
+
+    /**
+     * @param OrdersProcessor $ordersProcessor
+     * @param Config $yotpoConfig
+     * @param ResourceConnection $resourceConnection
+     * @param YotpoOrdersLogger $yotpoOrdersLogger
+     */
+    public function __construct(
+        OrdersProcessor $ordersProcessor,
+        Config $yotpoConfig,
+        ResourceConnection $resourceConnection,
+        YotpoOrdersLogger $yotpoOrdersLogger
+    ) {
+        $this->yotpoOrdersLogger = $yotpoOrdersLogger;
+        parent::__construct($ordersProcessor, $yotpoConfig, $resourceConnection);
+    }
+
     /**
      * @param Observer $observer
      * @throws LocalizedException
@@ -26,9 +64,33 @@ class SalesOrderShipmentSaveAfter extends OrderMain implements ObserverInterface
             return;
         }
         $order = $shipment->getOrder();
-        if ($order && $order->getEntityId()) {
-            $order->setData(self::SYNCED_TO_YOTPO_ORDER, 0);
-            $this->processOrderSync($order);
+        if (!$order || !$order->getEntityId()) {
+            return;
         }
+
+        $order->setData(self::SYNCED_TO_YOTPO_ORDER, 0);
+        $this->reQueueOrder($order);
+
+        if (!$this->yotpoConfig->isRealTimeOrdersSyncActive($order->getStoreId())) {
+            return;
+        }
+
+        $orderId = $order->getId();
+        if (isset($this->realTimeSyncQueued[$orderId])) {
+            return;
+        }
+        $this->realTimeSyncQueued[$orderId] = true;
+
+        $shipment->getResource()->addCommitCallback(function () use ($order) {
+            try {
+                $this->syncOrderNow($order);
+            } catch (\Throwable $e) {
+                $this->yotpoOrdersLogger->errorLog(
+                    'Deferred real-time order sync failed - Order ID: ' . $order->getId() .
+                    ' - ' . $e->getMessage(),
+                    []
+                );
+            }
+        });
     }
 }

--- a/Test/Unit/Observer/Order/OrderMainTest.php
+++ b/Test/Unit/Observer/Order/OrderMainTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Yotpo\Core\Test\Unit\Observer\Order;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Sales\Model\Order;
+use PHPUnit\Framework\TestCase;
+use Yotpo\Core\Model\Config;
+use Yotpo\Core\Model\Sync\Orders\Processor as OrdersProcessor;
+use Yotpo\Core\Observer\Order\OrderMain;
+
+/**
+ * Regression guard for the reQueueOrder()/syncOrderNow() split introduced so the shipment-save
+ * observer can defer its real-time sync past commit. SalesOrderPaymentSaveAfter and
+ * AdminSalesOrderAddressUpdate both still call processOrderSync() directly and must see
+ * identical end-to-end behavior after the split.
+ */
+class OrderMainTest extends TestCase
+{
+    /**
+     * @param OrdersProcessor $ordersProcessor
+     * @param Config $yotpoConfig
+     * @return OrderMain
+     */
+    private function createOrderMain($ordersProcessor, $yotpoConfig)
+    {
+        $connection = $this->createMock(\Magento\Framework\DB\Adapter\AdapterInterface::class);
+        $resourceConnection = $this->createMock(ResourceConnection::class);
+        $resourceConnection->method('getConnection')->willReturn($connection);
+        $resourceConnection->method('getTableName')->willReturnArgument(0);
+
+        return new OrderMain($ordersProcessor, $yotpoConfig, $resourceConnection);
+    }
+
+    /**
+     * @param int $entityId
+     * @return Order
+     */
+    private function createOrder($entityId = 5)
+    {
+        $order = $this->createMock(Order::class);
+        $order->method('getId')->willReturn($entityId);
+        $order->method('getStoreId')->willReturn(1);
+        return $order;
+    }
+
+    public function testProcessOrderSyncReQueuesAndCallsProcessOrderWhenRealTimeIsActive(): void
+    {
+        $ordersProcessor = $this->createMock(OrdersProcessor::class);
+        $ordersProcessor->expects($this->once())
+            ->method('updateOrderAttribute')
+            ->with([5], OrderMain::SYNCED_TO_YOTPO_ORDER, 0);
+        $ordersProcessor->expects($this->once())->method('processOrder');
+
+        $yotpoConfig = $this->createMock(Config::class);
+        $yotpoConfig->method('isRealTimeOrdersSyncActive')->willReturn(true);
+
+        $orderMain = $this->createOrderMain($ordersProcessor, $yotpoConfig);
+        $orderMain->processOrderSync($this->createOrder());
+    }
+
+    public function testProcessOrderSyncReQueuesButSkipsProcessOrderWhenRealTimeIsOff(): void
+    {
+        $ordersProcessor = $this->createMock(OrdersProcessor::class);
+        $ordersProcessor->expects($this->once())->method('updateOrderAttribute');
+        $ordersProcessor->expects($this->never())->method('processOrder');
+
+        $yotpoConfig = $this->createMock(Config::class);
+        $yotpoConfig->method('isRealTimeOrdersSyncActive')->willReturn(false);
+
+        $orderMain = $this->createOrderMain($ordersProcessor, $yotpoConfig);
+        $orderMain->processOrderSync($this->createOrder());
+    }
+}

--- a/Test/Unit/Observer/Order/SalesOrderShipmentSaveAfterTest.php
+++ b/Test/Unit/Observer/Order/SalesOrderShipmentSaveAfterTest.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace Yotpo\Core\Test\Unit\Observer\Order;
+
+use Magento\Framework\App\ResourceConnection;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Shipment;
+use PHPUnit\Framework\TestCase;
+use Yotpo\Core\Model\Config;
+use Yotpo\Core\Model\Sync\Orders\Logger as YotpoOrdersLogger;
+use Yotpo\Core\Model\Sync\Orders\Processor as OrdersProcessor;
+use Yotpo\Core\Observer\Order\SalesOrderShipmentSaveAfter;
+
+/**
+ * The shipment-save observer must not read shipment data until the shipment's transaction has
+ * actually committed, because sales_order_shipment_save_after fires while sales_shipment_item
+ * rows do not exist yet. The re-queue is synchronous (touches only sync bookkeeping); the
+ * real-time API call is deferred to a commit callback, with a dedupe guard so two shipments on
+ * the same order in one request don't schedule it twice.
+ */
+class SalesOrderShipmentSaveAfterTest extends TestCase
+{
+    /**
+     * @param OrdersProcessor $ordersProcessor
+     * @param Config $yotpoConfig
+     * @param YotpoOrdersLogger $logger
+     * @return SalesOrderShipmentSaveAfter
+     */
+    private function createObserver($ordersProcessor, $yotpoConfig, $logger)
+    {
+        $connection = $this->createMock(\Magento\Framework\DB\Adapter\AdapterInterface::class);
+        $resourceConnection = $this->createMock(ResourceConnection::class);
+        $resourceConnection->method('getConnection')->willReturn($connection);
+        $resourceConnection->method('getTableName')->willReturnArgument(0);
+
+        return new SalesOrderShipmentSaveAfter($ordersProcessor, $yotpoConfig, $resourceConnection, $logger);
+    }
+
+    /**
+     * @param int $entityId
+     * @return Order
+     */
+    private function createOrder($entityId)
+    {
+        $order = $this->createMock(Order::class);
+        $order->method('getId')->willReturn($entityId);
+        $order->method('getEntityId')->willReturn($entityId);
+        $order->method('getStoreId')->willReturn(1);
+        return $order;
+    }
+
+    /**
+     * @param Order $order
+     * @param callable|null &$capturedCallback set to the closure passed to addCommitCallback,
+     *        or left untouched if it's never called
+     * @return Shipment
+     */
+    private function createShipment($order, &$capturedCallback = null)
+    {
+        $resource = $this->createMock(AbstractResource::class);
+        $resource->method('addCommitCallback')->willReturnCallback(function ($callback) use (&$capturedCallback) {
+            $capturedCallback = $callback;
+        });
+
+        $shipment = $this->createMock(Shipment::class);
+        $shipment->method('getOrder')->willReturn($order);
+        $shipment->method('getResource')->willReturn($resource);
+        return $shipment;
+    }
+
+    /**
+     * @param Shipment $shipment
+     * @return Observer
+     */
+    private function createObserverEvent($shipment)
+    {
+        $event = new Event(['shipment' => $shipment]);
+        return new Observer(['event' => $event]);
+    }
+
+    public function testReQueuesSynchronouslyWithoutCallingProcessOrder(): void
+    {
+        $ordersProcessor = $this->createMock(OrdersProcessor::class);
+        $ordersProcessor->expects($this->once())
+            ->method('updateOrderAttribute')
+            ->with([5], 'synced_to_yotpo_order', 0);
+        $ordersProcessor->expects($this->never())->method('processOrder');
+
+        $yotpoConfig = $this->createMock(Config::class);
+        $yotpoConfig->method('isRealTimeOrdersSyncActive')->willReturn(true);
+
+        $order = $this->createOrder(5);
+        $shipment = $this->createShipment($order);
+
+        $observer = $this->createObserver($ordersProcessor, $yotpoConfig, $this->createMock(YotpoOrdersLogger::class));
+        $observer->execute($this->createObserverEvent($shipment));
+    }
+
+    public function testCommitCallbackSyncsAfterCommit(): void
+    {
+        $ordersProcessor = $this->createMock(OrdersProcessor::class);
+        $ordersProcessor->expects($this->once())->method('processOrder');
+
+        $yotpoConfig = $this->createMock(Config::class);
+        $yotpoConfig->method('isRealTimeOrdersSyncActive')->willReturn(true);
+
+        $order = $this->createOrder(5);
+        $capturedCallback = null;
+        $shipment = $this->createShipment($order, $capturedCallback);
+
+        $observer = $this->createObserver($ordersProcessor, $yotpoConfig, $this->createMock(YotpoOrdersLogger::class));
+        $observer->execute($this->createObserverEvent($shipment));
+
+        $this->assertIsCallable($capturedCallback, 'addCommitCallback() must be called during execute()');
+        $capturedCallback();
+    }
+
+    public function testRealTimeOffSkipsRegisteringTheCallbackEntirely(): void
+    {
+        // The setting is checked before registering anything, not inside the deferred
+        // callback - no point scheduling work that would just no-op after commit.
+        $ordersProcessor = $this->createMock(OrdersProcessor::class);
+        $ordersProcessor->expects($this->never())->method('processOrder');
+
+        $yotpoConfig = $this->createMock(Config::class);
+        $yotpoConfig->method('isRealTimeOrdersSyncActive')->willReturn(false);
+
+        $order = $this->createOrder(5);
+        $capturedCallback = null;
+        $shipment = $this->createShipment($order, $capturedCallback);
+
+        $observer = $this->createObserver($ordersProcessor, $yotpoConfig, $this->createMock(YotpoOrdersLogger::class));
+        $observer->execute($this->createObserverEvent($shipment));
+
+        $this->assertNull($capturedCallback, 'addCommitCallback() must not be called when real-time sync is off');
+    }
+
+    public function testTwoShipmentsForTheSameOrderInOneRequestOnlyScheduleTheSyncOnce(): void
+    {
+        $ordersProcessor = $this->createMock(OrdersProcessor::class);
+        $yotpoConfig = $this->createMock(Config::class);
+        $yotpoConfig->method('isRealTimeOrdersSyncActive')->willReturn(true);
+
+        $order = $this->createOrder(5);
+        $firstCallback = null;
+        $secondCallback = null;
+        $firstShipment = $this->createShipment($order, $firstCallback);
+        $secondShipment = $this->createShipment($order, $secondCallback);
+
+        $observer = $this->createObserver($ordersProcessor, $yotpoConfig, $this->createMock(YotpoOrdersLogger::class));
+        $observer->execute($this->createObserverEvent($firstShipment));
+        $observer->execute($this->createObserverEvent($secondShipment));
+
+        $this->assertIsCallable($firstCallback, 'the first shipment must schedule the deferred sync');
+        $this->assertNull($secondCallback, 'a second shipment for the same order must not schedule it again');
+    }
+
+    public function testDeferredFailureIsCaughtAndLoggedNotPropagated(): void
+    {
+        $ordersProcessor = $this->createMock(OrdersProcessor::class);
+        $ordersProcessor->method('processOrder')->willThrowException(new \RuntimeException('boom'));
+
+        $yotpoConfig = $this->createMock(Config::class);
+        $yotpoConfig->method('isRealTimeOrdersSyncActive')->willReturn(true);
+
+        $logger = $this->createMock(YotpoOrdersLogger::class);
+        $logger->expects($this->once())
+            ->method('errorLog')
+            ->with($this->stringContains('boom'));
+
+        $order = $this->createOrder(5);
+        $capturedCallback = null;
+        $shipment = $this->createShipment($order, $capturedCallback);
+
+        $observer = $this->createObserver($ordersProcessor, $yotpoConfig, $logger);
+        $observer->execute($this->createObserverEvent($shipment));
+
+        // Must not throw - the whole point is that a deferred sync failure can't escape into
+        // Magento's commit-callback machinery and disrupt anything else.
+        $capturedCallback();
+    }
+}


### PR DESCRIPTION
## Ticket
https://yotpoent.atlassian.net/browse/TS-41

## What's wrong

`SalesOrderShipmentSaveAfter` fires on `sales_order_shipment_save_after` - while the shipment's own database transaction is still open. At that point the shipment's header row exists, but its line items (`sales_shipment_item`) haven't been written yet.

The observer calls `processOrderSync()`, which (when Real Time Sync is on) immediately builds the Yotpo payload and calls the API right then:

```php
if ($order && $order->getEntityId()) {
    $order->setData(self::SYNCED_TO_YOTPO_ORDER, 0);
    $this->processOrderSync($order);   // reads shipment items that don't exist yet
}
```

Since the items aren't there, it sends `fulfilled_items: []`. Yotpo rejects that with a `400`, and that `400` gets stored as a terminal response code - the order can never be resynced correctly again, real-time or otherwise.

## The fix

`processOrderSync()` did two things as one inseparable call: re-queue the order (safe, just bookkeeping) and call the API (needs the order's data to actually exist). Split it into `reQueueOrder()` and `syncOrderNow()` so a caller can run one without the other - `processOrderSync()` itself still calls both back to back, so the other two observers that use it (`SalesOrderPaymentSaveAfter`, `AdminSalesOrderAddressUpdate`) see no behavior change.

`SalesOrderShipmentSaveAfter` now:
- runs `reQueueOrder()` immediately, same as before
- checks Real Time Sync up front - if it's off, nothing else happens, the regular cron picks the order up
- otherwise, defers `syncOrderNow()` to the shipment resource's commit callback (`addCommitCallback`), so it only runs once the transaction has actually committed and the items exist
- guards against scheduling the same order twice if two shipments save for it in one request
- wraps the deferred call in a `try`/`catch(\Throwable)` and logs a failure instead of letting it escape into Magento's commit-callback machinery

Real-time sync itself isn't touched - same trigger, same request, just reading the data at the right moment instead of too early.

## Testing

Reproduced locally: Real Time Sync on, `shipments_flag` on, place → invoice → ship an order - `response_code = 400`, payload shows `fulfilled_items: []`. Applied the fix, same flow on a fresh order - `response_code = 200`, payload shows the real shipment date, real items, and the shipment's own increment id. Also confirmed Real Time Sync off no longer registers a callback at all, and two shipments for the same order in one request only trigger one sync.

```
vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist \
  vendor/yotpo/module-yotpo-core/Test/Unit/Observer/Order/OrderMainTest.php \
  vendor/yotpo/module-yotpo-core/Test/Unit/Observer/Order/SalesOrderShipmentSaveAfterTest.php
```

7 tests pass with the fix; verified red by temporarily reverting the guard and the deferral separately - both caught by the tests.

---

One of several PRs on this ticket. They ship together under a single version bump in its own PR, so there's no version change here.