### PR TITLE
fix(orders): don't let a real-time sync failure disable the cron fallback

### DIFF
--- a/Model/Sync/Orders/Processor.php
+++ b/Model/Sync/Orders/Processor.php
@@ -390,17 +390,29 @@ class Processor extends Main
             $this->yotpoOrdersLogger->infoLog('Last sync date updated for order : '
                 . $magentoOrderId, []);
             if ($yotpoTableData) {
-                if (!$yotpoTableData['yotpo_id'] && array_key_exists($magentoOrderId, $yotpoSyncedOrders)) {
-                    $yotpoTableData['yotpo_id'] = $yotpoSyncedOrders[$magentoOrderId]['yotpo_id'];
+                if (!$this->config->canResync($yotpoTableData['response_code'], $yotpoTableData['yotpo_id'])) {
+                    // Real-time sync is an optimisation, not the authoritative source of truth.
+                    // A non-retryable response from this path is not trustworthy enough to
+                    // record as final - leave the order queued so cron retries it with complete
+                    // data instead.
+                    $this->yotpoOrdersLogger->errorLog(
+                        'Real-time sync got a non-retryable response for orderId: ' . $magentoOrderId .
+                        ', response code: ' . $yotpoTableData['response_code'] .
+                        ' - leaving it queued for cron to retry with complete data.'
+                    );
+                } else {
+                    if (!$yotpoTableData['yotpo_id'] && array_key_exists($magentoOrderId, $yotpoSyncedOrders)) {
+                        $yotpoTableData['yotpo_id'] = $yotpoSyncedOrders[$magentoOrderId]['yotpo_id'];
+                    }
+                    $yotpoTableData['order_id'] = $magentoOrderId;
+                    $yotpoTableData['synced_to_yotpo'] = $currentTime;
+                    $this->insertOrUpdateYotpoTableData($yotpoTableData);
+                    if ($this->config->canUpdateCustomAttribute($yotpoTableData['response_code'])) {
+                        $this->updateOrderAttribute($magentoOrderId, self::SYNCED_TO_YOTPO_ORDER, 1);
+                    }
+                    $this->yotpoOrdersLogger->infoLog('Order attribute updated to 1 for order : '
+                        . $magentoOrderId, []);
                 }
-                $yotpoTableData['order_id'] = $magentoOrderId;
-                $yotpoTableData['synced_to_yotpo'] = $currentTime;
-                $this->insertOrUpdateYotpoTableData($yotpoTableData);
-                if ($this->config->canUpdateCustomAttribute($yotpoTableData['response_code'])) {
-                    $this->updateOrderAttribute($magentoOrderId, self::SYNCED_TO_YOTPO_ORDER, 1);
-                }
-                $this->yotpoOrdersLogger->infoLog('Order attribute updated to 1 for order : '
-                    . $magentoOrderId, []);
             }
             $this->updateLastSyncDate($currentTime);
             $this->updateTotalOrdersSynced();

--- a/Test/Unit/Model/Sync/Orders/ProcessorTest.php
+++ b/Test/Unit/Model/Sync/Orders/ProcessorTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Yotpo\Core\Test\Unit\Model\Sync\Orders;
+
+use Magento\Sales\Model\Order;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Yotpo\Core\Model\Config;
+use Yotpo\Core\Model\Sync\Orders\Data as OrdersData;
+use Yotpo\Core\Model\Sync\Orders\Logger as YotpoOrdersLogger;
+use Yotpo\Core\Model\Sync\Orders\Processor;
+
+/**
+ * Real-time sync is an optimisation, not the authoritative source of truth. Only the cron path
+ * (processOrders()) may record a terminal, non-retryable response code for an order - a
+ * real-time attempt (processSingleEntity(), reached via the shipment/payment/address-update
+ * observers) must leave the order queued for cron's own attempt instead, since real-time runs at
+ * an inherently less reliable moment.
+ */
+class ProcessorTest extends TestCase
+{
+    /**
+     * Stubs everything processSingleEntity() reaches out to except the write-guard logic under
+     * test. getYotpoSyncedOrders() returns [] (a brand-new order, never synced before) so the
+     * "already-stored terminal code" branch is not exercised here - this test is about the
+     * response from THIS attempt.
+     *
+     * @param string $responseCode
+     * @return Processor&MockObject
+     */
+    private function createProcessor($responseCode)
+    {
+        $processor = $this->getMockBuilder(Processor::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods([
+                'checkMissingProducts',
+                'getYotpoSyncedOrders',
+                'syncOrder',
+                'prepareYotpoTableData',
+                'updateOrderAttribute',
+                'insertOrUpdateYotpoTableData',
+                'updateLastSyncDate',
+                'updateTotalOrdersSynced',
+            ])
+            ->getMock();
+
+        $processor->method('checkMissingProducts')->willReturn(false);
+        $processor->method('getYotpoSyncedOrders')->willReturn([]);
+        $processor->method('syncOrder')->willReturn(new \Magento\Framework\DataObject(['is_success' => true]));
+        $processor->method('prepareYotpoTableData')->willReturn([
+            'response_code' => $responseCode,
+            'yotpo_id' => null,
+        ]);
+
+        $data = $this->createMock(OrdersData::class);
+        $data->method('getMappedOrderStatuses')->willReturn(['processing' => 'pending']);
+
+        // canResync()/canUpdateCustomAttribute() are left real - they are the exact logic this
+        // fix has to interact with correctly, not something to mock away.
+        $config = $this->getMockBuilder(Config::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['isRealTimeOrdersSyncActive'])
+            ->getMock();
+        $config->method('isRealTimeOrdersSyncActive')->willReturn(true);
+
+        (new \ReflectionProperty(Processor::class, 'data'))->setValue($processor, $data);
+        (new \ReflectionProperty(Processor::class, 'config'))->setValue($processor, $config);
+        (new \ReflectionProperty(Processor::class, 'yotpoOrdersLogger'))
+            ->setValue($processor, $this->createMock(YotpoOrdersLogger::class));
+
+        return $processor;
+    }
+
+    /**
+     * @return Order&MockObject
+     */
+    private function createOrder()
+    {
+        $order = $this->createMock(Order::class);
+        $order->method('getEntityId')->willReturn(7);
+        $order->method('getId')->willReturn(7);
+        $order->method('getStatus')->willReturn('processing');
+        $order->method('getCustomerId')->willReturn(null);
+        $order->method('getCouponCode')->willReturn(null);
+        return $order;
+    }
+
+    public function testSuccessIsPersistedAndOrderMarkedSynced(): void
+    {
+        $processor = $this->createProcessor('200');
+        $processor->expects($this->once())->method('insertOrUpdateYotpoTableData');
+        $processor->expects($this->once())->method('updateOrderAttribute')
+            ->with(7, Processor::SYNCED_TO_YOTPO_ORDER, 1);
+
+        $processor->processSingleEntity($this->createOrder());
+    }
+
+    public function testNonRetryableFailureIsNotPersisted(): void
+    {
+        $processor = $this->createProcessor('400');
+        $processor->expects($this->never())->method('insertOrUpdateYotpoTableData');
+        $processor->expects($this->never())->method('updateOrderAttribute');
+
+        $processor->processSingleEntity($this->createOrder());
+    }
+
+    public function testRetryableFailureIsStillPersistedButNotMarkedSynced(): void
+    {
+        // 500 is network-retriable - canResync() already treats it as safe to write, and
+        // cron will still pick it up again regardless, so this must not be suppressed.
+        $processor = $this->createProcessor('500');
+        $processor->expects($this->once())->method('insertOrUpdateYotpoTableData');
+        $processor->expects($this->never())->method('updateOrderAttribute');
+
+        $processor->processSingleEntity($this->createOrder());
+    }
+}


### PR DESCRIPTION
## Ticket
https://yotpoent.atlassian.net/browse/TS-41

## What's wrong

`processSingleEntity()` - the real-time sync path, reached from the shipment/payment/address-update observers - writes the API response code unconditionally, the same way `processOrders()` (cron) does:

```php
if ($yotpoTableData) {
    $this->insertOrUpdateYotpoTableData($yotpoTableData);   // writes response_code, whatever it is
    if ($this->config->canUpdateCustomAttribute($yotpoTableData['response_code'])) {
        $this->updateOrderAttribute($magentoOrderId, self::SYNCED_TO_YOTPO_ORDER, 1);   // marks "done"
    }
}
```

`canUpdateCustomAttribute()` returns true for a success *or* for a genuinely non-retryable failure - correct for cron, which has complete, settled data and can reasonably call an order dead. Real-time doesn't have that standing: it runs mid-request, at a less reliable moment, so a non-retryable-looking response from it isn't trustworthy enough to treat as final. Today it's treated identically, so a real-time failure can permanently disable the cron fallback for that order.

This got worse as a side effect of Release 1: before the status-masking fix, every failure (real or not) was recorded as a fake code that `canResync()` treats as retryable, so these orders just retried forever, harmlessly. Restoring real status codes was necessary, but it also means a real-time failure is now recorded faithfully - and faithfully means permanent.

## The fix

Check `canResync()` before writing. On a non-retryable response, skip the write and the "mark synced" update entirely, log the real status, and leave the order exactly where the earlier re-queue left it (`synced_to_yotpo_order = 0`, `response_code = '000'`) so cron gets its own attempt with complete data. A success, or a retryable failure (429/5xx), is still written normally - `canResync()` already returns true for any success code, so this only ever intercepts genuine non-retryable failures.

`processOrders()` (cron) is untouched - it keeps full authority to record a genuine terminal failure. That's correct: cron has complete, settled data, so giving up on a truly dead order there is the right call.

**Found along the way, not fixed here:** the existing `catch` block in this method calls `$this->yotpoOrdersLogger->addError(...)`, which doesn't exist on the installed Monolog version (3.10.0 removed the legacy `addXxx()` methods - only `error()` remains). That call would fatal if ever hit. Used the working `errorLog()` for the new code instead; the pre-existing call is unrelated to this fix and needs its own ticket.

## Testing

Reproduced live by temporarily reverting the shipment-timing fix from the parent PR (keeping this fix active), to get a genuine `400` from Yotpo's real API on a fresh order: `orders.log` showed the real-time attempt fail with `400`, this fix's log line fire ("leaving it queued for cron to retry with complete data"), and the DB confirmed `response_code` stayed `'000'` and the order stayed queued. Running cron afterward synced the same shipment successfully - `200`, correct `fulfilled_items`.

Also confirmed the other direction: forced a genuinely empty shipment (deleted its item rows directly) so *cron itself* hit the same `400`. Cron correctly stamped `response_code = 400` and marked the order `synced_to_yotpo_order = 1` - permanently excluded from retry, exactly as before this change. Confirms cron's own authority to call a truly dead order dead is untouched.

```
vendor/bin/phpunit -c dev/tests/unit/phpunit.xml.dist \
  vendor/yotpo/module-yotpo-core/Test/Unit/Model/Sync/Orders/ProcessorTest.php
```

3 tests, verified red on the non-retryable case before the fix, green after, and confirmed red again by temporarily reverting the guard.

---

Stacked on the shipment-timing fix (touches `Observer/Order/OrderMain.php`, shared with this PR's `Processor.php` change only through the invariant, not the code itself). One of several PRs on this ticket - they ship together under a single version bump in its own PR, so there's no version change here.